### PR TITLE
feat(gatsby-source-url): allow developer to control srcset widths generated with args.srcSetBreakpoints

### DIFF
--- a/packages/gatsby-source-url/src/createImgixFluidFieldConfig.ts
+++ b/packages/gatsby-source-url/src/createImgixFluidFieldConfig.ts
@@ -54,16 +54,13 @@ export const createImgixFluidFieldConfig = <TSource, TContext>({
       type: ImgixUrlParamsInputType,
       defaultValue: {},
     },
-    // TODO: handle
     maxWidth: {
       type: GraphQLInt,
       defaultValue: DEFAULT_FLUID_MAX_WIDTH,
     },
-    // TODO: handle
     maxHeight: {
       type: GraphQLInt,
     },
-    // TODO: handle
     srcSetBreakpoints: {
       type: new GraphQLList(GraphQLInt),
     },

--- a/packages/gatsby-source-url/src/objectBuilders.ts
+++ b/packages/gatsby-source-url/src/objectBuilders.ts
@@ -49,13 +49,13 @@ export const buildFluidObject = ({
 
   const srcset = client.buildSrcSet(url, imgixParams, {
     maxWidth,
+    widths: args.srcSetBreakpoints,
   });
 
   /* TODO: handle these */
   //  ({
   //   aspectRatio,
   //   maxWidth: maxWidth,
-  //   srcSetBreakpoints: args.srcSetBreakpoints,
   // });
 
   return {

--- a/packages/gatsby-source-url/test/createResolvers.test.ts
+++ b/packages/gatsby-source-url/test/createResolvers.test.ts
@@ -138,6 +138,32 @@ describe('createResolvers', () => {
         expect(fluidFieldResult.srcSetWebp).toMatch('ar=2%3A1');
       });
     });
+
+    it('should create srcsets based off the breakpoints argument', async () => {
+      const srcSetBreakpoints = [100, 200];
+      const fluidFieldResult: FluidObject = await resolveField({
+        field: 'fluid',
+        fieldParams: {
+          srcSetBreakpoints,
+        },
+      });
+
+      const expectSrcsetToHaveWidths = (widths: number[]) => (
+        srcset: string | undefined,
+      ) => {
+        if (srcset == null) {
+          fail();
+        }
+        expect(getSrcsetWidths(srcset)).toEqual(srcSetBreakpoints);
+      };
+
+      const expectSrcSetToHaveBreakpoints = expectSrcsetToHaveWidths(
+        srcSetBreakpoints,
+      );
+
+      expectSrcSetToHaveBreakpoints(fluidFieldResult.srcSet);
+      expectSrcSetToHaveBreakpoints(fluidFieldResult.srcSetWebp);
+    });
   });
 });
 

--- a/packages/gatsby-source-url/test/createResolvers.test.ts
+++ b/packages/gatsby-source-url/test/createResolvers.test.ts
@@ -8,6 +8,7 @@ import * as R from 'ramda';
 import { createLogger, trace } from '../src/common/log';
 import { createResolvers } from '../src/gatsby-node';
 import { IGatsbySourceUrlOptions } from '../src/publicTypes';
+import { getSrcsetWidths } from './utils/getSrcsetWidths';
 
 const log = createLogger('test:createResolvers');
 
@@ -83,25 +84,14 @@ describe('createResolvers', () => {
           fieldParams: { maxWidth: 500 },
         });
 
-        const getSrcsetWidths: (srcset: string) => string[] = R.pipe(
-          R.split(','),
-          R.map(R.trim),
-          R.map(R.split(' ')),
-          R.map<readonly string[], string>(R.last),
-        );
-
         const expectSrcsetToNotHaveWidthsGT = (maxWidth: number) => (
           srcset: string | undefined,
         ) => {
           if (srcset == null) {
             fail();
           }
-          pipe(
-            srcset,
-            getSrcsetWidths,
-            R.map(parseInt),
-            R.all(R.lte(R.__, maxWidth)),
-            (v) => expect(v).toBe(true),
+          pipe(srcset, getSrcsetWidths, R.all(R.lte(R.__, maxWidth)), (v) =>
+            expect(v).toBe(true),
           );
         };
 

--- a/packages/gatsby-source-url/test/utils/getSrcsetWidths.ts
+++ b/packages/gatsby-source-url/test/utils/getSrcsetWidths.ts
@@ -4,4 +4,5 @@ export const getSrcsetWidths: (srcset: string) => number[] = R.pipe(
   R.map(R.trim),
   R.map(R.split(' ')),
   R.map<readonly string[], string>(R.last),
-  R.map(parseInt));
+  R.map(parseInt),
+);

--- a/packages/gatsby-source-url/test/utils/getSrcsetWidths.ts
+++ b/packages/gatsby-source-url/test/utils/getSrcsetWidths.ts
@@ -1,0 +1,7 @@
+import * as R from 'ramda';
+export const getSrcsetWidths: (srcset: string) => number[] = R.pipe(
+  R.split(','),
+  R.map(R.trim),
+  R.map(R.split(' ')),
+  R.map<readonly string[], string>(R.last),
+  R.map(parseInt));


### PR DESCRIPTION
```
{
  imgixImage(url: ...) {
    fluid(srcSetBreakpoints: [100, 200]) {
      srcset // image.jpg?w=100 100w, .../image.jpg?w=200 200w
    }
  }
}
```