### PR TITLE
feat(gatsby-source-url): basic fixed field and tests

### DIFF
--- a/packages/dev-and-e2e-test-environment/cypress/e2e/gatsby-source-url.js
+++ b/packages/dev-and-e2e-test-environment/cypress/e2e/gatsby-source-url.js
@@ -21,4 +21,13 @@ describe("gatsby-source-url", () => {
         expect($img[0].naturalWidth).to.be.greaterThan(0)
       })
   })
+
+  it("fixed image loads", () => {
+    cy.findByAltText("Fixed Image")
+      .should("be.visible")
+      .and($img => {
+        // "naturalWidth" and "naturalHeight" are set when the image loads
+        expect($img[0].naturalWidth).to.be.greaterThan(0)
+      })
+  })
 })

--- a/packages/dev-and-e2e-test-environment/src/pages/e2e/gatsby-source-url.tsx
+++ b/packages/dev-and-e2e-test-environment/src/pages/e2e/gatsby-source-url.tsx
@@ -1,5 +1,5 @@
 import { graphql } from "gatsby"
-import Img, { FluidObject } from "gatsby-image"
+import Img, { FixedObject, FluidObject } from "gatsby-image"
 import React from "react"
 
 const GatsbySourceUrl = ({ data }: { data: IPageData }) => {
@@ -12,6 +12,7 @@ const GatsbySourceUrl = ({ data }: { data: IPageData }) => {
           alt="Fluid Image"
         />
       </div>
+      <Img fixed={data.testImage.fixed} alt="Fixed Image" />
     </div>
   )
 }
@@ -20,6 +21,7 @@ type IPageData = {
   testImage: {
     url: string
     fluid: FluidObject
+    fixed: FixedObject
   }
 }
 export const query = graphql`
@@ -28,6 +30,9 @@ export const query = graphql`
       url(imgixParams: { w: 10, h: 10 })
       fluid {
         ...GatsbySourceImgixFluid
+      }
+      fixed(width: 100) {
+        ...GatsbySourceImgixFixed
       }
     }
   }

--- a/packages/gatsby-source-url/fragments.js
+++ b/packages/gatsby-source-url/fragments.js
@@ -22,3 +22,26 @@ export const GatsbySourceImgixFluid_noBase64 = graphql`
     sizes
   }
 `;
+
+export const GatsbySourceImgixFixed = graphql`
+  fragment GatsbySourceImgixFixed on SourceImgixFixed {
+    base64
+    width
+    height
+    src
+    srcSet
+    srcWebp
+    srcSetWebp
+  }
+`;
+
+export const GatsbySourceImgixFixed_noBase64 = graphql`
+  fragment GatsbySourceImgixFixed_noBase64 on SourceImgixFixed {
+    width
+    height
+    src
+    srcSet
+    srcWebp
+    srcSetWebp
+  }
+`;

--- a/packages/gatsby-source-url/fragments.js
+++ b/packages/gatsby-source-url/fragments.js
@@ -1,6 +1,5 @@
 import { graphql } from 'gatsby';
 
-// TODO: add base64 when available
 export const GatsbySourceImgixFluid = graphql`
   fragment GatsbySourceImgixFluid on SourceImgixFluid {
     aspectRatio
@@ -9,6 +8,7 @@ export const GatsbySourceImgixFluid = graphql`
     srcSet
     srcSetWebp
     sizes
+    base64
   }
 `;
 

--- a/packages/gatsby-source-url/package.json
+++ b/packages/gatsby-source-url/package.json
@@ -37,6 +37,7 @@
     "camel-case": "^4.1.1",
     "debug": "^4.1.1",
     "fp-ts": "^2.8.1",
+    "fp-ts-contrib": "^0.1.18",
     "imgix-core-js": "^2.3.1",
     "imgix-url-params": "^11.7.0",
     "io-ts": "^2.2.9",

--- a/packages/gatsby-source-url/src/createImgixFixedFieldConfig.ts
+++ b/packages/gatsby-source-url/src/createImgixFixedFieldConfig.ts
@@ -106,43 +106,6 @@ export const createImgixFixedFieldConfig = <TSource, TContext>({
         ),
       TE.getOrElseW(() => T.of(undefined)),
     )(),
-
-  // pipe(
-  //   rootValue,
-  //   resolveUrlFromSourceData(resolveUrl),
-  //   TE.chain((url) =>
-  //     pipe(
-  //       url,
-  //       url => resolveDimensions({
-  //         url,
-  //         resolveWidth,
-  //         resolveHeight,
-  //         cache,
-  //         secureUrlToken,
-  //       }),
-  //       TE.map(([width, height]) =>
-  //         buildImgixFixed({
-  //           url,
-  //           sourceWidth: width,
-  //           sourceHeight: height,
-  //           secureUrlToken,
-  //           args: {
-  //             ...args,
-  //             imgixParams: {
-  //               ...defaultImgixParams,
-  //               ...args.imgixParams,
-  //             },
-  //             placeholderImgixParams: {
-  //               ...defaultPlaceholderImgixParams,
-  //               ...args.placeholderImgixParams,
-  //             },
-  //           },
-  //         }),
-  //       ),
-  //     ),
-  //   ),
-  //   TE.getOrElseW(() => T.of(undefined)),
-  // )(),
 });
 
 export const createImgixFixedSchemaFieldConfig = <TSource, TContext>(

--- a/packages/gatsby-source-url/src/createImgixFixedFieldConfig.ts
+++ b/packages/gatsby-source-url/src/createImgixFixedFieldConfig.ts
@@ -1,0 +1,155 @@
+import { Do } from 'fp-ts-contrib/lib/Do';
+import { pipe } from 'fp-ts/lib/function';
+import * as T from 'fp-ts/lib/Task';
+import * as TE from 'fp-ts/lib/TaskEither';
+import { GatsbyCache } from 'gatsby';
+import { FixedObject } from 'gatsby-image';
+import { GraphQLFieldConfig, GraphQLInt } from 'graphql';
+import { ComposeFieldConfigAsObject } from 'graphql-compose';
+import ImgixClient from 'imgix-core-js';
+import {
+  createGatsbySourceImgixFixedFieldType,
+  ImgixUrlParamsInputType,
+} from './graphqlTypes';
+import { buildImgixFixed } from './objectBuilders';
+import { ImgixFixedArgs, ImgixFixedArgsResolved } from './publicTypes';
+import { resolveDimensions } from './resolveDimensions';
+import {
+  ImgixSourceDataResolver,
+  resolveUrlFromSourceData,
+  taskEitherFromSourceDataResolver,
+  TaskOptionFromTE,
+} from './utils';
+
+export const DEFAULT_FIXED_WIDTH = 8192;
+
+interface CreateImgixFixedFieldConfigArgs<TSource> {
+  imgixClient: ImgixClient;
+  resolveUrl: ImgixSourceDataResolver<TSource, string>;
+  resolveWidth?: ImgixSourceDataResolver<TSource, number>;
+  resolveHeight?: ImgixSourceDataResolver<TSource, number>;
+  cache: GatsbyCache;
+}
+
+export const createImgixFixedFieldConfig = <TSource, TContext>({
+  imgixClient,
+  resolveUrl,
+  resolveWidth = () => undefined,
+  resolveHeight = () => undefined,
+  cache,
+}: CreateImgixFixedFieldConfigArgs<TSource>): GraphQLFieldConfig<
+  TSource,
+  TContext,
+  ImgixFixedArgsResolved
+> => ({
+  type: createGatsbySourceImgixFixedFieldType(cache),
+  args: {
+    width: {
+      type: GraphQLInt,
+      // TODO: refactor to TS default args for type safety and functionality ()
+      defaultValue: DEFAULT_FIXED_WIDTH,
+    },
+    height: {
+      type: GraphQLInt,
+    },
+    quality: {
+      type: GraphQLInt,
+    },
+    imgixParams: {
+      type: ImgixUrlParamsInputType,
+      defaultValue: {},
+    },
+    placeholderImgixParams: {
+      type: ImgixUrlParamsInputType,
+      defaultValue: {},
+    },
+  },
+  resolve: (
+    rootValue: TSource,
+    args: ImgixFixedArgsResolved,
+  ): Promise<FixedObject | undefined> =>
+    pipe(
+      Do(TE.taskEither)
+        .let('rootValue', rootValue)
+        .sequenceSL(({ rootValue }) => ({
+          url: resolveUrlFromSourceData(resolveUrl)(rootValue),
+          manualWidth: pipe(
+            rootValue,
+            taskEitherFromSourceDataResolver(resolveWidth),
+            TaskOptionFromTE,
+            TE.fromTask,
+          ),
+          manualHeight: pipe(
+            rootValue,
+            taskEitherFromSourceDataResolver(resolveHeight),
+            TaskOptionFromTE,
+            TE.fromTask,
+          ),
+        }))
+        .bindL('dimensions', ({ url, manualWidth, manualHeight }) =>
+          resolveDimensions({
+            url,
+            manualHeight,
+            manualWidth,
+            cache,
+            client: imgixClient,
+          }),
+        )
+        .return(({ url, dimensions: { width, height } }) =>
+          buildImgixFixed({
+            client: imgixClient,
+            url,
+            sourceWidth: width,
+            sourceHeight: height,
+            args,
+          }),
+        ),
+      TE.getOrElseW(() => T.of(undefined)),
+    )(),
+
+  // pipe(
+  //   rootValue,
+  //   resolveUrlFromSourceData(resolveUrl),
+  //   TE.chain((url) =>
+  //     pipe(
+  //       url,
+  //       url => resolveDimensions({
+  //         url,
+  //         resolveWidth,
+  //         resolveHeight,
+  //         cache,
+  //         secureUrlToken,
+  //       }),
+  //       TE.map(([width, height]) =>
+  //         buildImgixFixed({
+  //           url,
+  //           sourceWidth: width,
+  //           sourceHeight: height,
+  //           secureUrlToken,
+  //           args: {
+  //             ...args,
+  //             imgixParams: {
+  //               ...defaultImgixParams,
+  //               ...args.imgixParams,
+  //             },
+  //             placeholderImgixParams: {
+  //               ...defaultPlaceholderImgixParams,
+  //               ...args.placeholderImgixParams,
+  //             },
+  //           },
+  //         }),
+  //       ),
+  //     ),
+  //   ),
+  //   TE.getOrElseW(() => T.of(undefined)),
+  // )(),
+});
+
+export const createImgixFixedSchemaFieldConfig = <TSource, TContext>(
+  args: CreateImgixFixedFieldConfigArgs<TSource>,
+): ComposeFieldConfigAsObject<TSource, TContext, ImgixFixedArgs> =>
+  createImgixFixedFieldConfig(args) as ComposeFieldConfigAsObject<
+    TSource,
+    TContext,
+    ImgixFixedArgs
+  >;

--- a/packages/gatsby-source-url/src/createRootImgixImageType.ts
+++ b/packages/gatsby-source-url/src/createRootImgixImageType.ts
@@ -2,6 +2,7 @@ import { GatsbyCache } from 'gatsby';
 import { GraphQLFieldConfig, GraphQLObjectType, GraphQLString } from 'graphql';
 import type ImgixClient from 'imgix-core-js';
 import * as R from 'ramda';
+import { createImgixFixedFieldConfig } from './createImgixFixedFieldConfig';
 import { createImgixFluidFieldConfig } from './createImgixFluidFieldConfig';
 import { createImgixUrlFieldConfig } from './createImgixUrlFieldConfig';
 import { IGatsbySourceUrlRootArgs } from './publicTypes';
@@ -12,7 +13,7 @@ type IRootSource = {
 export const createRootImgixImageType = (
   imgixClient: ImgixClient,
   cache: GatsbyCache,
-  // fix any
+  // TODO: fix any
 ): GraphQLFieldConfig<any, any, IGatsbySourceUrlRootArgs> => ({
   args: {
     url: {
@@ -27,6 +28,11 @@ export const createRootImgixImageType = (
         resolveUrl: R.prop('rawUrl'),
       }),
       fluid: createImgixFluidFieldConfig<IRootSource, unknown>({
+        imgixClient,
+        resolveUrl: R.prop('rawUrl'),
+        cache,
+      }),
+      fixed: createImgixFixedFieldConfig<IRootSource, unknown>({
         imgixClient,
         resolveUrl: R.prop('rawUrl'),
         cache,

--- a/packages/gatsby-source-url/src/graphqlTypes.ts
+++ b/packages/gatsby-source-url/src/graphqlTypes.ts
@@ -4,7 +4,7 @@ import { GatsbyCache } from 'gatsby';
  * The GraphQL type of the fluid field.
  * Corresponding TS type is FluidObject from gatsby-image.
  */
-import { FluidObject } from 'gatsby-image';
+import { FixedObject, FluidObject } from 'gatsby-image';
 import {
   GraphQLBoolean,
   GraphQLFloat,
@@ -82,8 +82,10 @@ export const ImgixUrlParamsInputType = new GraphQLInputObjectType({
   }, {} as GraphQLInputFieldConfigMap),
 });
 
-const createBase64ConfigWithFluidResolver = (cache: GatsbyCache) =>
-  createImgixBase64FieldConfig<FluidObject>({
+const createBase64ConfigWithResolver = <T extends FluidObject | FixedObject>(
+  cache: GatsbyCache,
+) =>
+  createImgixBase64FieldConfig<T>({
     resolveUrl: (obj) => obj.base64,
     cache,
   });
@@ -92,13 +94,30 @@ export const createGatsbySourceImgixFluidFieldType = (cache: GatsbyCache) =>
   new GraphQLObjectType({
     name: 'SourceImgixFluid',
     fields: {
-      base64: createBase64ConfigWithFluidResolver(cache),
+      base64: createBase64ConfigWithResolver<FluidObject>(cache),
       src: { type: new GraphQLNonNull(GraphQLString) },
       srcSet: { type: new GraphQLNonNull(GraphQLString) },
       srcWebp: { type: new GraphQLNonNull(GraphQLString) },
       srcSetWebp: { type: new GraphQLNonNull(GraphQLString) },
       sizes: { type: new GraphQLNonNull(GraphQLString) },
       aspectRatio: { type: new GraphQLNonNull(GraphQLFloat) },
+    },
+  });
+
+export const createGatsbySourceImgixFixedFieldType = (
+  cache: GatsbyCache,
+): GraphQLObjectType<FixedObject> =>
+  new GraphQLObjectType({
+    name: 'SourceImgixFixed',
+    fields: {
+      base64: createBase64ConfigWithResolver<FixedObject>(cache),
+      src: { type: new GraphQLNonNull(GraphQLString) },
+      srcSet: { type: new GraphQLNonNull(GraphQLString) },
+      srcWebp: { type: new GraphQLNonNull(GraphQLString) },
+      srcSetWebp: { type: new GraphQLNonNull(GraphQLString) },
+      sizes: { type: new GraphQLNonNull(GraphQLString) },
+      width: { type: new GraphQLNonNull(GraphQLInt) },
+      height: { type: new GraphQLNonNull(GraphQLInt) },
     },
   });
 

--- a/packages/gatsby-source-url/src/objectBuilders.ts
+++ b/packages/gatsby-source-url/src/objectBuilders.ts
@@ -1,13 +1,18 @@
-import { FluidObject } from 'gatsby-image';
+import { FixedObject, FluidObject } from 'gatsby-image';
 import ImgixClient from 'imgix-core-js';
 import * as R from 'ramda';
-import { ImgixFluidArgsResolved, ImgixUrlParams } from './publicTypes';
+import { log, trace } from './common/log';
+import { DEFAULT_FIXED_WIDTH } from './createImgixFixedFieldConfig';
+import {
+  ImgixFixedArgsResolved,
+  ImgixFluidArgsResolved,
+  ImgixUrlParams,
+} from './publicTypes';
 export type BuildImgixFluidArgs = {
   client: ImgixClient;
   url: string;
   sourceWidth: number;
   sourceHeight: number;
-  secureUrlToken?: string;
   args: ImgixFluidArgsResolved;
 };
 
@@ -25,7 +30,6 @@ export const buildFluidObject = ({
   url,
   sourceWidth,
   sourceHeight,
-  secureUrlToken,
   args,
 }: BuildImgixFluidArgs): FluidObject => {
   const maxWidthAndHeightSet = args.maxHeight != null && args.maxWidth != null;
@@ -94,6 +98,117 @@ export const buildFluidObject = ({
     srcWebp: srcWebp,
     srcSet: srcset,
     srcSetWebp: srcsetWebp,
+    // TODO: use max-width here
     sizes: '(min-width: 8192px) 8192px, 100vw',
   };
 };
+
+export type BuildImgixFixedArgs = {
+  client: ImgixClient;
+  url: string;
+  sourceWidth: number;
+  sourceHeight: number;
+  args: ImgixFixedArgsResolved;
+};
+export function buildImgixFixed({
+  client,
+  url,
+  sourceWidth,
+  sourceHeight,
+  args,
+}: BuildImgixFixedArgs): FixedObject {
+  const aspectRatio = (() => {
+    if (args.imgixParams.ar != null) {
+      return parseAspectRatioFloatFromString(args.imgixParams.ar);
+    }
+    if (args.height != null && args.width != null) {
+      return args.width / args.height;
+    }
+    return sourceWidth / sourceHeight;
+  })();
+  log(
+    args.width,
+    args.height,
+    aspectRatio,
+    Math.round(args.width / aspectRatio),
+  );
+
+  const { width, height } = ((): { width: number; height: number } => {
+    if (args.width != null && args.height != null) {
+      return { width: args.width, height: args.height };
+    } else if (args.width != null) {
+      return {
+        width: args.width,
+        height: Math.round(args.width / aspectRatio),
+      };
+    } else if (args.height != null) {
+      return {
+        width: Math.round(args.height * aspectRatio),
+        height: args.height,
+      };
+    } else {
+      return {
+        width: DEFAULT_FIXED_WIDTH,
+        height: Math.round(DEFAULT_FIXED_WIDTH / aspectRatio),
+      };
+    }
+  })();
+
+  const imgixParams = {
+    fit: 'crop',
+    ...args.imgixParams,
+    w: width,
+    h: height,
+  };
+
+  const base64 = client.buildURL(url, {
+    ...DEFAULT_LQIP_PARAMS,
+    ...args.imgixParams,
+    ...args.placeholderImgixParams,
+  });
+
+  // We have to spread parameters because .buildURL and .buildSrscSet mutates params. GH issue: https://github.com/imgix/imgix-core-js/issues/158
+  const src = client.buildURL(url, { ...imgixParams });
+  const srcWebp = client.buildURL(url, {
+    ...imgixParams,
+    fm: 'webp',
+  });
+
+  const srcsetOptions = {
+    // maxWidth,
+    // widths: args.srcSetBreakpoints,
+  };
+  const srcsetImgixParams = imgixParams;
+  const srcset = client.buildSrcSet(
+    url,
+    { ...srcsetImgixParams },
+    srcsetOptions,
+  );
+  const srcsetWebp = client.buildSrcSet(
+    url,
+    {
+      ...srcsetImgixParams,
+      fm: 'webp',
+    },
+    srcsetOptions,
+  );
+
+  trace('buildFixedImage output')({
+    base64,
+    width,
+    height,
+    src,
+    srcWebp,
+    srcSet: srcset,
+    srcSetWebp: srcsetWebp,
+  });
+  return {
+    base64,
+    width,
+    height,
+    src,
+    srcWebp,
+    srcSet: srcset,
+    srcSetWebp: srcsetWebp,
+  };
+}

--- a/packages/gatsby-source-url/src/publicTypes.ts
+++ b/packages/gatsby-source-url/src/publicTypes.ts
@@ -36,10 +36,29 @@ export interface ImgixFluidArgs {
   placeholderImgixParams?: ImgixUrlParams;
 }
 
+// Internal use only
+// TODO: refactor to private types (along with fixed args below)
 export interface ImgixFluidArgsResolved {
   maxWidth: number;
   maxHeight?: number;
   srcSetBreakpoints?: number[];
+  imgixParams: ImgixUrlParams;
+  placeholderImgixParams: ImgixUrlParams;
+}
+
+export interface ImgixFixedArgs {
+  width?: number;
+  height?: number;
+  quality?: number;
+  imgixParams?: ImgixUrlParams;
+  placeholderImgixParams?: ImgixUrlParams;
+}
+
+// Internal use only
+export interface ImgixFixedArgsResolved {
+  width: number;
+  height?: number;
+  quality?: number;
   imgixParams: ImgixUrlParams;
   placeholderImgixParams: ImgixUrlParams;
 }

--- a/packages/gatsby-source-url/src/utils.ts
+++ b/packages/gatsby-source-url/src/utils.ts
@@ -1,5 +1,8 @@
+import { flow } from 'fp-ts/lib/function';
+import * as O from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { getObjectSemigroup } from 'fp-ts/lib/Semigroup';
+import * as T from 'fp-ts/lib/Task';
 import * as TE from 'fp-ts/lib/TaskEither';
 import { TaskEither } from 'fp-ts/lib/TaskEither';
 import _fetch, { Response } from 'node-fetch';
@@ -51,3 +54,11 @@ export const fetchJSON = <A>(url: string): TaskEither<Error, A> =>
     fetch,
     TE.chain((res) => TE.rightTask(() => res.json())),
   );
+
+export const TaskOptionFromTE = <T>(
+  taskEither: TE.TaskEither<any, T>,
+): T.Task<O.Option<T>> =>
+  TE.fold<any, T, O.Option<T>>(
+    () => T.of(O.none),
+    flow(O.some, T.of),
+  )(taskEither);

--- a/packages/gatsby-source-url/test/createResolvers.test.ts
+++ b/packages/gatsby-source-url/test/createResolvers.test.ts
@@ -3,7 +3,7 @@
 
 import { pipe } from 'fp-ts/lib/function';
 import { CreateResolversArgsPatched, PluginOptions } from 'gatsby';
-import { FluidObject } from 'gatsby-image';
+import { FixedObject, FluidObject } from 'gatsby-image';
 import * as R from 'ramda';
 import { createLogger, trace } from '../src/common/log';
 import { createResolvers } from '../src/gatsby-node';
@@ -43,6 +43,15 @@ describe('createResolvers', () => {
         expect(fluidFieldResult.srcWebp).toMatch('ixlib=gatsby');
         expect(fluidFieldResult.srcSet).toMatch('ixlib=gatsby');
         expect(fluidFieldResult.srcSetWebp).toMatch('ixlib=gatsby');
+      });
+      it('should generate a fluid width srcset', async () => {
+        const fluidFieldResult: FluidObject = await resolveField({
+          field: 'fluid',
+        });
+
+        // Don't need to do too much work here since imgix-core-js handles everything under the hood
+        expect(fluidFieldResult.srcSet).toMatch(/\d*w,/);
+        expect(fluidFieldResult.srcSetWebp).toMatch(/\d*w,/);
       });
     });
 
@@ -237,6 +246,29 @@ describe('createResolvers', () => {
 
       expect(fluidFieldResult.src).not.toMatch('fm=webp');
       expect(fluidFieldResult.srcSet).not.toMatch('fm=webp');
+    });
+  });
+
+  describe.only('fixed field', () => {
+    describe('src field', () => {
+      it('should return return an imgix url in the src fields', async () => {
+        const fluidFieldResult: FixedObject = await resolveField({
+          field: 'fixed',
+        });
+
+        expect(fluidFieldResult.src).toMatch('ixlib=gatsby');
+        expect(fluidFieldResult.srcWebp).toMatch('ixlib=gatsby');
+        expect(fluidFieldResult.srcSet).toMatch('ixlib=gatsby');
+        expect(fluidFieldResult.srcSetWebp).toMatch('ixlib=gatsby');
+      });
+      it('should generate a fixed width srcset', async () => {
+        const fluidFieldResult: FixedObject = await resolveField({
+          field: 'fixed',
+        });
+
+        expect(fluidFieldResult.srcSet).toMatch('1x');
+        expect(fluidFieldResult.srcSetWebp).toMatch('1x');
+      });
     });
   });
 });

--- a/packages/gatsby-source-url/test/createResolvers.test.ts
+++ b/packages/gatsby-source-url/test/createResolvers.test.ts
@@ -249,7 +249,7 @@ describe('createResolvers', () => {
     });
   });
 
-  describe.only('fixed field', () => {
+  describe('fixed field', () => {
     describe('src field', () => {
       it('should return return an imgix url in the src fields', async () => {
         const fluidFieldResult: FixedObject = await resolveField({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7738,6 +7738,11 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
+fp-ts-contrib@^0.1.18:
+  version "0.1.18"
+  resolved "https://registry.yarnpkg.com/fp-ts-contrib/-/fp-ts-contrib-0.1.18.tgz#5134322ece1bb57c8435a18da3127330a5c79add"
+  integrity sha512-1JV2eLM30DI5Ptic88i7Kv9Y2RRCoZx1VCGrDHNoN/fAx4CJm4V0iF+p6aGtXxQjRZCJnlGH70gLcd+iStHuYA==
+
 fp-ts@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.8.1.tgz#b1812171469a7c0fcbc0b770ac2568f8356d1993"


### PR DESCRIPTION
```graphql
{
    testImage: imgixImage(url: "/blog/unsplash-kiss.jpg") {
      fixed(width: 100) {
        ...GatsbySourceImgixFixed
      }
    }
  }
```

now works