### PR TITLE
feat(gatsby-source-url): disableIxlibParam global setting

### DIFF
--- a/packages/gatsby-source-url/README.md
+++ b/packages/gatsby-source-url/README.md
@@ -166,7 +166,7 @@ The plugin options that can be specified in `gatsby-config.js` are:
 
 For security and diagnostic purposes, we tag all requests with the language and version of library used to generate the URL.
 
-To disable this, set `disableLibraryParam` to `false` in the plugin configuration options.
+To disable this, set `disableIxlibParam` to `true` in the plugin configuration options.
 
 ```js
 // gatsby-config.js
@@ -178,7 +178,7 @@ module.exports = {
       resolve: `@imgix/gatsby-source-url`,
       options: {
         domain: '<your imgix domain, e.g. acme.imgix.net>',
-        disableLibraryParam: false, // <-- set this to false
+        disableIxlibParam: true, // <-- set this to true
       },
     },
   ],

--- a/packages/gatsby-source-url/src/common/ioTs.ts
+++ b/packages/gatsby-source-url/src/common/ioTs.ts
@@ -1,0 +1,44 @@
+import { pipe } from 'fp-ts/lib/function';
+import * as t from 'io-ts';
+import { Optional } from './tsUtils';
+
+const typeOptional = <P extends t.Props>(obj: P) =>
+  pipe(obj, (v) => t.type<P>(v), fixOptionals);
+
+/**
+ * Type lambda returning a union of key names from input type P having type A
+ */
+type FieldsWithType<T, Type> = {
+  [K in keyof T]-?: Type extends T[K] ? K : never;
+}[keyof T];
+
+/**
+ * Dual for FieldsWith - returns the rest of the fields
+ */
+type FieldsWithoutType<T, Type> = Exclude<keyof T, FieldsWithType<T, Type>>;
+
+// Original implementation
+// type MakeOptional<T, Type = undefined> = Pick<T, FieldsWithoutType<T, Type>> & Partial<Pick<T, FieldsWithType<T, Type>>>;
+
+/**
+ * Type lambda returning new type with all fields within P having type U marked as optional
+ */
+type MakeOptional<T, Type = undefined> = Optional<T, FieldsWithType<T, Type>>;
+
+/**
+ * Fix signature by marking all fields with undefined as optional
+ */
+const fixOptionals = <C extends t.Mixed>(
+  c: C,
+): t.Type<MakeOptional<t.TypeOf<C>>, t.OutputOf<C>, t.InputOf<C>> => c;
+
+/**
+ * Just an alias for T | undefined coded
+ */
+const optional = <C extends t.Mixed>(
+  c: C,
+): t.Type<t.TypeOf<C> | undefined, t.OutputOf<C>, t.InputOf<C>> =>
+  t.union([t.undefined, c]);
+
+export * from 'io-ts';
+export { typeOptional, optional };

--- a/packages/gatsby-source-url/src/common/tsUtils.ts
+++ b/packages/gatsby-source-url/src/common/tsUtils.ts
@@ -1,0 +1,1 @@
+export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<T>;

--- a/packages/gatsby-source-url/src/gatsby-node.ts
+++ b/packages/gatsby-source-url/src/gatsby-node.ts
@@ -48,7 +48,9 @@ export const createResolvers: GatsbyNode['createResolvers'] = async (
           ),
         ),
       )
-      .bindL('imgixClient', ({ options }) => createImgixClient(options))
+      .bindL('imgixClient', ({ options: { domain } }) =>
+        createImgixClient({ domain }),
+      )
       .bind(
         'packageVersion',
         pipe(
@@ -56,9 +58,11 @@ export const createResolvers: GatsbyNode['createResolvers'] = async (
           E.fromNullable(new Error('Could not read package version.')),
         ),
       )
-      .doL(({ imgixClient, packageVersion }) => {
+      .doL(({ options, imgixClient, packageVersion }) => {
         imgixClient.includeLibraryParam = false;
-        (imgixClient as any).settings.libraryParam = `gatsby-source-url-${packageVersion}`;
+        if (options.disableIxlibParam !== true) {
+          (imgixClient as any).settings.libraryParam = `gatsby-source-url-${packageVersion}`;
+        }
         return E.right(imgixClient);
       })
       .letL('rootQueryTypeMap', ({ imgixClient, options }) => ({

--- a/packages/gatsby-source-url/src/publicTypes.ts
+++ b/packages/gatsby-source-url/src/publicTypes.ts
@@ -1,6 +1,6 @@
 import imgixUrlParameters from 'imgix-url-params/dist/parameters.json';
-import * as t from 'io-ts';
 import R from 'ramda';
+import * as t from './common/ioTs';
 
 type IImgixParamsKey =
   | keyof ImgixUrlParametersSpec['parameters']
@@ -28,17 +28,12 @@ const ImgixParamsIOTS = t.partial({
 });
 export type IImgixParams = t.TypeOf<typeof ImgixParamsIOTS>;
 
-export const GatsbySourceUrlOptions = t.type({
+export const GatsbySourceUrlOptions = t.typeOptional({
   domain: t.string,
-  defaultImgixParams: t.union([ImgixParamsIOTS, t.undefined]),
+  defaultImgixParams: t.optional(ImgixParamsIOTS),
+  disableIxlibParam: t.optional(t.boolean),
 });
 export type IGatsbySourceUrlOptions = t.TypeOf<typeof GatsbySourceUrlOptions>;
-
-const imgixParamsTest2: IImgixParams = {
-  auto: ['format'],
-};
-
-export type IImgixFixedImageData = {};
 
 export type IGatsbySourceUrlRootArgs = {
   url: string;

--- a/packages/gatsby-source-url/test/createResolvers.test.ts
+++ b/packages/gatsby-source-url/test/createResolvers.test.ts
@@ -12,6 +12,47 @@ import { getSrcsetWidths } from './utils/getSrcsetWidths';
 
 const log = createLogger('test:createResolvers');
 
+const testForEveryFieldSrcAndSrcSet = ({
+  name,
+  resolveFieldOpts,
+  assertion,
+}: {
+  name: string;
+  resolveFieldOpts?: Partial<Parameters<typeof resolveField>[0]>;
+  assertion: (url: string) => void;
+}) => {
+  it(`${name} for url field`, async () => {
+    const urlFieldResult = await resolveField({
+      field: 'url',
+      ...resolveFieldOpts,
+    });
+
+    assertion(urlFieldResult);
+  });
+  it(`${name} for fluid field`, async () => {
+    const fieldResult = await resolveField({
+      field: 'fluid',
+      ...resolveFieldOpts,
+    });
+
+    assertion(fieldResult.src);
+    assertion(fieldResult.srcSet);
+    assertion(fieldResult.srcWebp);
+    assertion(fieldResult.srcSetWebp);
+  });
+  it(`${name} for fixed field`, async () => {
+    const fieldResult = await resolveField({
+      field: 'fixed',
+      ...resolveFieldOpts,
+    });
+
+    assertion(fieldResult.src);
+    assertion(fieldResult.srcSet);
+    assertion(fieldResult.srcWebp);
+    assertion(fieldResult.srcSetWebp);
+  });
+};
+
 describe('createResolvers', () => {
   describe('url field', () => {
     it('resolves with a src', async () => {
@@ -371,6 +412,22 @@ describe('createResolvers', () => {
       expect(fieldResult.srcSet).toMatch('txt=Overridden');
       expect(fieldResult.srcWebp).toMatch('txt=Overridden');
       expect(fieldResult.srcSetWebp).toMatch('txt=Overridden');
+    });
+  });
+
+  describe('ixlib param', () => {
+    testForEveryFieldSrcAndSrcSet({
+      name: 'should be included in src by default',
+      assertion: (url) => expect(url).toMatch('ixlib=gatsby-source-url'),
+    });
+    testForEveryFieldSrcAndSrcSet({
+      name: 'should not exist in src when disableIxlibParam is set',
+      resolveFieldOpts: {
+        appConfig: {
+          disableIxlibParam: true,
+        },
+      },
+      assertion: (url) => expect(url).not.toMatch('ixlib=gatsby-source-url'),
     });
   });
 });

--- a/packages/gatsby-source-url/test/createResolvers.test.ts
+++ b/packages/gatsby-source-url/test/createResolvers.test.ts
@@ -314,21 +314,20 @@ describe('createResolvers', () => {
   });
 
   describe('default parameters', () => {
-    it('should set parameters on url field', async () => {
-      const urlFieldResult = await resolveField({
-        field: 'url',
+    testForEveryFieldSrcAndSrcSet({
+      name: 'should set default parameters',
+      resolveFieldOpts: {
         appConfig: {
           defaultImgixParams: {
             txt: 'Default',
           },
         },
-      });
-
-      expect(urlFieldResult).toMatch('txt=Default');
+      },
+      assertion: (url) => expect(url).toMatch('txt=Default'),
     });
-    it('should allow default parameters to be overridden for url field', async () => {
-      const urlFieldResult = await resolveField({
-        field: 'url',
+    testForEveryFieldSrcAndSrcSet({
+      name: 'should allow default parameters to be overridden',
+      resolveFieldOpts: {
         appConfig: {
           defaultImgixParams: {
             txt: 'Default',
@@ -339,79 +338,8 @@ describe('createResolvers', () => {
             txt: 'Overridden',
           },
         },
-      });
-
-      expect(urlFieldResult).toMatch('txt=Overridden');
-    });
-    it('should set parameters on fluid field', async () => {
-      const fieldResult = await resolveField({
-        field: 'fluid',
-        appConfig: {
-          defaultImgixParams: {
-            txt: 'Default',
-          },
-        },
-      });
-
-      expect(fieldResult.src).toMatch('txt=Default');
-      expect(fieldResult.srcSet).toMatch('txt=Default');
-      expect(fieldResult.srcWebp).toMatch('txt=Default');
-      expect(fieldResult.srcSetWebp).toMatch('txt=Default');
-    });
-    it('should allow default parameters to be overridden for fluid field', async () => {
-      const fieldResult = await resolveField({
-        field: 'fluid',
-        appConfig: {
-          defaultImgixParams: {
-            txt: 'Default',
-          },
-        },
-        fieldParams: {
-          imgixParams: {
-            txt: 'Overridden',
-          },
-        },
-      });
-
-      expect(fieldResult.src).toMatch('txt=Overridden');
-      expect(fieldResult.srcSet).toMatch('txt=Overridden');
-      expect(fieldResult.srcWebp).toMatch('txt=Overridden');
-      expect(fieldResult.srcSetWebp).toMatch('txt=Overridden');
-    });
-    it('should set parameters on fluid field', async () => {
-      const fieldResult = await resolveField({
-        field: 'fixed',
-        appConfig: {
-          defaultImgixParams: {
-            txt: 'Default',
-          },
-        },
-      });
-
-      expect(fieldResult.src).toMatch('txt=Default');
-      expect(fieldResult.srcSet).toMatch('txt=Default');
-      expect(fieldResult.srcWebp).toMatch('txt=Default');
-      expect(fieldResult.srcSetWebp).toMatch('txt=Default');
-    });
-    it('should allow default parameters to be overridden for fixed field', async () => {
-      const fieldResult = await resolveField({
-        field: 'fixed',
-        appConfig: {
-          defaultImgixParams: {
-            txt: 'Default',
-          },
-        },
-        fieldParams: {
-          imgixParams: {
-            txt: 'Overridden',
-          },
-        },
-      });
-
-      expect(fieldResult.src).toMatch('txt=Overridden');
-      expect(fieldResult.srcSet).toMatch('txt=Overridden');
-      expect(fieldResult.srcWebp).toMatch('txt=Overridden');
-      expect(fieldResult.srcSetWebp).toMatch('txt=Overridden');
+      },
+      assertion: (url) => expect(url).toMatch('txt=Overridden'),
     });
   });
 


### PR DESCRIPTION
```js
// gatsby-config.js
module.exports = {
  //...
  plugins: [
    // your other plugins here
    {
      resolve: `@imgix/gatsby-source-url`,
      options: {
        domain: '<your imgix domain, e.g. acme.imgix.net>',
        disableIxlibParam: true, // <-- set this to true
      },
    },
  ],
};
```