### PR TITLE
feat(gatsby-source-url): support web proxy sources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,8 @@ Publish stable versions from main, and prerelease versions from beta.
 
 ## Project setup
 
-```
-yarn install
-```
+1. Run `yarn` to install dependencies
+2. Add a .env file to the root of the project with the contents from "Gatsby .env file" in 1Password.
 
 ## Build the entire project
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:e2e": "yarn workspace dev-and-e2e-test-environment run test:e2e",
     "test:e2e:ci": "yarn workspace dev-and-e2e-test-environment run test:e2e:ci",
     "tdd": "run-p tdd:unit tdd:e2e",
-    "tdd:unit": "yarn jest --watch",
+    "tdd:unit": "yarn jest --watch --setupFiles dotenv/config",
     "tdd:e2e": "yarn test:e2e",
     "run-publish": "yarn build ; lerna publish"
   },

--- a/packages/gatsby-source-url/README.md
+++ b/packages/gatsby-source-url/README.md
@@ -26,6 +26,7 @@
 - [Usage](#usage)
     * [Fluid Images](#fluid-images)
     * [Fixed Images](#fixed-images)
+    * [Using a Web Proxy Source](#using-a-web-proxy-source)
 - [API](#api)
     * [GraphQL](#graphql)
         + [GraphQL Fragments](#graphql-fragments)
@@ -141,6 +142,53 @@ A full list of imgix parameters can be found [here](https://docs.imgix.com/apis/
 <!-- An example of this mode in a full working Gatsby repo can be found on CodeSandbox.
 
 [![Edit @imgix/gatsby-transform-url Fixed Example](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/imgixgatsby-transform-url-fixed-example-ce324?fontsize=14&hidenavigation=1&theme=dark) -->
+
+## Using a Web Proxy Source
+
+If you would like to proxy images from another domain, you should set up a [Web Proxy Source](https://docs.imgix.com/setup/creating-sources/web-proxy). After doing this, you can use this source with this plugin as follows:
+
+1. Set the plugin config in `gatsby-config.js` to the following:
+
+```js
+module.exports = {
+  //...
+  plugins: [
+    // your other plugins here
+    {
+      resolve: `@imgix/gatsby-source-url`,
+      options: {
+        domain: '<your proxy source domain, e.g. my-proxy-source.imgix.net>',
+        secureURLToken: '...', // <-- now required, your "Token" from your source page
+        defaultImgixParams: ['auto', 'format'],
+      },
+    },
+  ],
+};
+```
+
+2. Pass a **fully-qualified URL** to the `url` parameter in the GraphQL API. For example, to render a fixed image, a page would look like this:
+
+```jsx
+import gql from 'graphql-tag';
+import Img from 'gatsby-image';
+
+export default ({ data }) => {
+  return <Img fixed={data.imgixImage.fixed} />;
+};
+
+export const query = gql`
+  {
+    imgixImage(url: "https://acme.com/my-image-to-proxy.jpg") {
+      # Now this is a full URL
+      fixed(
+        width: 960 # Width (in px) is required
+      ) {
+        ...GatsbySourceImgixFixed
+      }
+    }
+  }
+`;
+```
 
 # API
 

--- a/packages/gatsby-source-url/src/common/imgix-core-js-wrapper.ts
+++ b/packages/gatsby-source-url/src/common/imgix-core-js-wrapper.ts
@@ -8,3 +8,6 @@ export const createImgixClient = (
     () => new ImgixClient(options),
     (e) => (e instanceof Error ? e : new Error('unknown error')),
   );
+
+export type IBuildImgixUrl = ImgixClient['buildURL'];
+export type IBuildImgixSrcSet = ImgixClient['buildSrcSet'];

--- a/packages/gatsby-source-url/src/common/ioTs.ts
+++ b/packages/gatsby-source-url/src/common/ioTs.ts
@@ -2,8 +2,8 @@ import { pipe } from 'fp-ts/lib/function';
 import * as t from 'io-ts';
 import { Optional } from './tsUtils';
 
-const typeOptional = <P extends t.Props>(obj: P) =>
-  pipe(obj, (v) => t.type<P>(v), fixOptionals);
+const typeOptional = <P extends t.Props>(obj: P, name?: string) =>
+  pipe(t.type<P>(obj, name), fixOptionals);
 
 /**
  * Type lambda returning a union of key names from input type P having type A
@@ -39,6 +39,22 @@ const optional = <C extends t.Mixed>(
   c: C,
 ): t.Type<t.TypeOf<C> | undefined, t.OutputOf<C>, t.InputOf<C>> =>
   t.union([t.undefined, c]);
+
+export function fromEnum<EnumType extends string>(
+  enumName: string,
+  theEnum: Record<string, EnumType>,
+): t.Type<EnumType, EnumType, unknown> {
+  const isEnumValue = (input: unknown): input is EnumType =>
+    Object.values<unknown>(theEnum).includes(input);
+
+  return new t.Type<EnumType>(
+    enumName,
+    isEnumValue,
+    (input, context) =>
+      isEnumValue(input) ? t.success(input) : t.failure(input, context),
+    t.identity,
+  );
+}
 
 export * from 'io-ts';
 export { typeOptional, optional };

--- a/packages/gatsby-source-url/src/createRootImgixImageType.ts
+++ b/packages/gatsby-source-url/src/createRootImgixImageType.ts
@@ -24,6 +24,8 @@ export const createRootImgixImageType = (
   args: {
     url: {
       type: GraphQLNonNull(GraphQLString),
+      description:
+        'The path of the image to render. If using a Web Proxy Source, this can also be a fully-qualified URL.',
     },
   },
   type: new GraphQLObjectType<any, any, any>({

--- a/packages/gatsby-source-url/src/gatsby-node.ts
+++ b/packages/gatsby-source-url/src/gatsby-node.ts
@@ -30,10 +30,10 @@ export const onPreInit: GatsbyNode['onPreInit'] = (_: unknown) => {
   log('Loaded @imgix/gatsby-source-url (onPreInit)');
 };
 
-export const createResolvers: GatsbyNode['createResolvers'] = async (
+export const createResolvers: GatsbyNode['createResolvers'] = (
   { createResolvers: createResolversCb, cache }: CreateResolversArgsPatched,
   _options: PluginOptions<IGatsbySourceUrlOptions>,
-): Promise<void> =>
+): any =>
   pipe(
     Do(E.either)
       .bind(

--- a/packages/gatsby-source-url/src/gatsby-node.ts
+++ b/packages/gatsby-source-url/src/gatsby-node.ts
@@ -21,7 +21,7 @@ import path from 'path';
 import readPkgUp from 'read-pkg-up';
 import { createLogger } from './common/log';
 import { createRootImgixImageType } from './createRootImgixImageType';
-import { createImgixClient } from './imgix-core-js-wrapper';
+import { createImgixClient } from './common/imgix-core-js-wrapper';
 import { GatsbySourceUrlOptions, IGatsbySourceUrlOptions } from './publicTypes';
 
 const log = createLogger('gatsby-node');

--- a/packages/gatsby-source-url/src/gatsby-node.ts
+++ b/packages/gatsby-source-url/src/gatsby-node.ts
@@ -46,6 +46,20 @@ export const createResolvers: GatsbyNode['createResolvers'] = async (
                 `[@imgix/gatsby-source-url] The plugin config is not in the correct format.`,
               ),
           ),
+          E.chain((options) => {
+            if (
+              options.sourceType === 'webProxy' &&
+              (options.secureURLToken == null ||
+                options.secureURLToken.trim() === '')
+            ) {
+              return E.left(
+                new Error(
+                  `[@imgix/gatsby-source-url] the plugin option 'secureURLToken' is required when sourceType is 'webProxy'.`,
+                ),
+              );
+            }
+            return E.right(options);
+          }),
         ),
       )
       .bindL('imgixClient', ({ options: { domain, secureURLToken } }) =>

--- a/packages/gatsby-source-url/src/publicTypes.ts
+++ b/packages/gatsby-source-url/src/publicTypes.ts
@@ -2,38 +2,58 @@ import imgixUrlParameters from 'imgix-url-params/dist/parameters.json';
 import R from 'ramda';
 import * as t from './common/ioTs';
 
+export enum GatsbySourceUrlSourceType {
+  AmazonS3 = 's3',
+  GoogleCloudStorange = 'gcs',
+  MicrosoftAzure = 'azure',
+  WebFolder = 'webFolder',
+  WebProxy = 'webProxy',
+}
+
 type IImgixParamsKey =
   | keyof ImgixUrlParametersSpec['parameters']
   | keyof ImgixUrlParametersSpec['aliases'];
 
-const ImgixParamValueIOTS = t.union([
-  t.string,
-  t.number,
-  t.boolean,
-  t.undefined,
-  t.null,
-  t.array(t.string),
-  t.array(t.number),
-  t.array(t.boolean),
-]);
+const ImgixParamValueIOTS = t.union(
+  [
+    t.string,
+    t.number,
+    t.boolean,
+    t.undefined,
+    t.null,
+    t.array(t.string),
+    t.array(t.number),
+    t.array(t.boolean),
+  ],
+  'ImgixParamValue',
+);
 
 const mapToImgixParamValue = <TKey extends string>(
   obj: Record<TKey, unknown>,
 ): Record<TKey, typeof ImgixParamValueIOTS> =>
   R.mapObjIndexed(() => ImgixParamValueIOTS, obj);
 
-const ImgixParamsIOTS = t.partial({
-  ...mapToImgixParamValue(imgixUrlParameters.aliases),
-  ...mapToImgixParamValue(imgixUrlParameters.parameters),
-});
+const ImgixParamsIOTS = t.partial(
+  {
+    ...mapToImgixParamValue(imgixUrlParameters.aliases),
+    ...mapToImgixParamValue(imgixUrlParameters.parameters),
+  },
+  'ImgixParams',
+);
 export type IImgixParams = t.TypeOf<typeof ImgixParamsIOTS>;
 
-export const GatsbySourceUrlOptions = t.typeOptional({
-  domain: t.string,
-  defaultImgixParams: t.optional(ImgixParamsIOTS),
-  disableIxlibParam: t.optional(t.boolean),
-  secureURLToken: t.optional(t.string),
-});
+export const GatsbySourceUrlOptions = t.typeOptional(
+  {
+    domain: t.string,
+    defaultImgixParams: t.optional(ImgixParamsIOTS),
+    disableIxlibParam: t.optional(t.boolean),
+    secureURLToken: t.optional(t.string),
+    sourceType: t.optional(
+      t.fromEnum('GatsbySourceUrlSourceType', GatsbySourceUrlSourceType),
+    ),
+  },
+  'GatsbySourceUrlOptions',
+);
 export type IGatsbySourceUrlOptions = t.TypeOf<typeof GatsbySourceUrlOptions>;
 
 export type IGatsbySourceUrlRootArgs = {

--- a/packages/gatsby-source-url/test/createResolvers.test.ts
+++ b/packages/gatsby-source-url/test/createResolvers.test.ts
@@ -373,6 +373,24 @@ describe('createResolvers', () => {
 
       expect(createResolversLazy).toThrow('secureURLToken');
     });
+
+    const proxyUrl = 'https://assets.imgix.net/amsterdam.jpg';
+    testForEveryFieldSrcAndSrcSet({
+      name: `should encrypt path when sourceType set to 'webProxy'`,
+      resolveFieldOpts: {
+        appConfig: {
+          domain: 'proxy-demo.imgix.net',
+          sourceType: 'webProxy',
+          secureURLToken: process.env.PROXY_DEMO_TOKEN,
+        },
+        url: proxyUrl,
+      },
+      assertion: (url) => {
+        return expect(url).toMatch(
+          `https://proxy-demo.imgix.net/${encodeURIComponent(proxyUrl)}?`,
+        );
+      },
+    });
   });
 });
 

--- a/packages/gatsby-source-url/test/createResolvers.test.ts
+++ b/packages/gatsby-source-url/test/createResolvers.test.ts
@@ -476,23 +476,19 @@ const defaultAppConfig = {
   domain: 'assets.imgix.net',
   plugins: [],
 } as const;
-async function createRootResolversMap(
+function createRootResolversMap(
   _appConfig?: Partial<PluginOptions<IGatsbySourceUrlOptions>>,
 ) {
   const appConfig = R.mergeDeepRight(defaultAppConfig, _appConfig ?? {});
   const mockCreateResolversFunction = jest.fn();
-  try {
-    createResolvers &&
-      (await createResolvers(
-        ({
-          createResolvers: mockCreateResolversFunction,
-          cache: mockGatsbyCache,
-        } as any) as CreateResolversArgsPatched,
-        appConfig,
-      ));
-  } catch (err) {
-    throw fail(err);
-  }
+  createResolvers &&
+    createResolvers(
+      ({
+        createResolvers: mockCreateResolversFunction,
+        cache: mockGatsbyCache,
+      } as any) as CreateResolversArgsPatched,
+      appConfig,
+    );
   const resolverMap = mockCreateResolversFunction.mock.calls[0][0];
   return resolverMap;
 }

--- a/packages/gatsby-source-url/test/createResolvers.test.ts
+++ b/packages/gatsby-source-url/test/createResolvers.test.ts
@@ -362,6 +362,18 @@ describe('createResolvers', () => {
       assertion: (url) => expect(url).toMatch(/s=\w+/),
     });
   });
+
+  describe('web proxy sources', () => {
+    it(`should throw an error if app is configured with sourceType: 'webProxy' but no secureURLToken`, async () => {
+      const createResolversLazy = () =>
+        createRootResolversMap({
+          sourceType: 'webProxy',
+          domain: 'assets.imgix.net',
+        });
+
+      expect(createResolversLazy).toThrow('secureURLToken');
+    });
+  });
 });
 
 const mockGatsbyCache = {


### PR DESCRIPTION
This PR enables web proxy sources to be used with the following config

1. Set the plugin config in `gatsby-config.js` to the following:

```js
module.exports = {
  //...
  plugins: [
    // your other plugins here
    {
      resolve: `@imgix/gatsby-source-url`,
      options: {
        domain: '<your proxy source domain, e.g. my-proxy-source.imgix.net>',
        secureURLToken: '...', // <-- now required, your "Token" from your source page
        defaultImgixParams: ['auto', 'format'],
      },
    },
  ],
};
```

2. Pass a **fully-qualified URL** to the `url` parameter in the GraphQL API. For example, to render a fixed image, a page would look like this:

```jsx
import gql from 'graphql-tag';
import Img from 'gatsby-image';

export default ({ data }) => {
  return <Img fixed={data.imgixImage.fixed} />;
};

export const query = gql`
  {
    imgixImage(url: "https://acme.com/my-image-to-proxy.jpg") {
      # Now this is a full URL
      fixed(
        width: 960 # Width (in px) is required
      ) {
        ...GatsbySourceImgixFixed
      }
    }
  }
`;
```