### PR TITLE
docs: v1 upgrade information

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
         + [`buildFluidImageData`](#buildfluidimagedata)
 - [What is the `ixlib` Param on Every Request?](#what-is-the-ixlib-param-on-every-request)
 - [Roadmap](#roadmap)
+- [Upgrading from `@imgix/gatsby-transform-url`](#upgrading-from-imgixgatsby-transform-url)
 - [Contributors](#contributors)
 - [License](#license)
 
@@ -689,6 +690,21 @@ Below is a list of issues that contain all the high-level use-cases that we thou
 Other features:
 
 - [I want to have my imgix parameters in my Gatsby/GraphQL query be strongly-typed](https://github.com/imgix/gatsby/issues/5)
+# Upgrading from `@imgix/gatsby-transform-url`
+
+`@imgix/gatsby-transform-url` was deprecated in favor of combining these sub-projects into one single project, for simplicity.
+
+The functionality of that library can be found, unchanged, under this new package. Specifically, all that needs to changed is the import statements, e.g. from 
+
+```js
+import { buildFluidImageData } from '@imgix/gatsby-transform-url';
+```
+
+to
+
+```js
+import { buildFluidImageData } from '@imgix/gatsby';
+```
 
 # Contributors
 


### PR DESCRIPTION
~⚠️ This PR isn't intended to be merged!~ **Edit: I've reworked this to live on in the main repo so it's easier to find.**

The idea of this PR is just to review this branch, which I will use to do an NPM release to `@imgix/gatsby-transform-url` to mark it as deprecated in favour of the main repo/package.

The command I will use to deprecate this library is:

```sh
npm deprecate @imgix/gatsby-transform-url "functionality moved to another package: @imgix/gatsby. See upgrade instructions at https://github.com/imgix/gatsby/<sha1>/gatsby-transform-url/README.md#deprecation-notice"
```

This will be updated when the API of `@imgix/gatsby` is finalised.