### PR TITLE
docs(readme): add gastby-source-drupal config

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,17 @@ Then, you need to configure a field for this node type. The quickest way to conf
 },
 ```
 
+###### gatsby-source-drupal
+
+```js
+// Drupal
+{
+  nodeType: 'File',
+  getURL: (node) => node.url,
+  fieldName: 'imgixImage',
+},
+```
+
 ###### Manual config (if your node type doesn't exist above)
 
 ```js


### PR DESCRIPTION
## Description

Updated [README](https://github.com/imgix/gatsby/blob/luis/drupalSource/README.md) to include gatsby-source-drupal configuration.

## Checklist: Fixing typos/Doc change

- [ ] The target branch is `beta`. This is important for our CI/CD config.
- [x] Each commit follows the conventional commit spec format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.
