### PR TITLE
docs: fix typo and code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ The steps to setting this value correctly is:
 
    For example, for `ContentfulAsset`, it will display the following error message:
 
-   ```
+   ```txt
    Error when resolving URL value for node type ContentfulAsset. This
    probably means that the getURL function in gatsby-config.js is
    incorrectly set. Please read this project's README for detailed
@@ -702,7 +702,7 @@ import { buildFixedImageData } from '@imgix/gatsby';
 
 // Later, in a gatsby page/component.
 <Img
-  fluid={buildFixedImageData('https://assets.imgix.net/examples/pione.jpg', {
+  fixed={buildFixedImageData('https://assets.imgix.net/examples/pione.jpg', {
     // imgix parameters
     w: 960, // required
     h: 540, // required


### PR DESCRIPTION
There is a code block under the [Adding a fields item correctly](https://docs.imgix.com/libraries/gatsby#adding-a-fields-item-correctly) section that is displaying as multiple inline blocks on docs.imgix.com. There is a possibility that the markdown parser expects a language declaration here, so adding one should fix this.

<img width="650" alt="Screen Shot 2021-03-04 at 2 27 45 PM" src="https://user-images.githubusercontent.com/15919091/110039237-cb070a00-7cf5-11eb-81b6-a3841ddd9500.png">