### PR TITLE
config: update semantic release

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["github>imgix/renovate-config"]
+}

--- a/package.json
+++ b/package.json
@@ -119,6 +119,11 @@
             {
               "type": "docs",
               "release": "patch"
+            },
+            {
+              "type": "deps",
+              "scope": "deps",
+              "release": "patch"
             }
           ]
         }
@@ -146,7 +151,54 @@
           ]
         }
       ],
-      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits",
+          "writerOpts": {
+            "types": [
+              {
+                "type": "feat",
+                "section": "Features"
+              },
+              {
+                "type": "fix",
+                "section": "Bug Fixes"
+              },
+              {
+                "type": "docs",
+                "section": "Documentation",
+                "hidden": false
+              },
+              {
+                "type": "deps",
+                "section": "Dependency Updates",
+                "hidden": false
+              },
+              {
+                "type": "chore",
+                "hidden": true
+              },
+              {
+                "type": "style",
+                "hidden": true
+              },
+              {
+                "type": "refactor",
+                "hidden": true
+              },
+              {
+                "type": "perf",
+                "hidden": true
+              },
+              {
+                "type": "test",
+                "hidden": true
+              }
+            ]
+          }
+        }
+      ],
       "@semantic-release/changelog",
       "@semantic-release/npm",
       [


### PR DESCRIPTION
This PR pulls in the renovate config from imgix/renovate-config and also updates semantic release to be compatible with this config