### PR TITLE
fix: use camelCased ixlib param

### DIFF
--- a/src/modules/gatsby-transform-node/gatsby-node.ts
+++ b/src/modules/gatsby-transform-node/gatsby-node.ts
@@ -120,7 +120,7 @@ const setupImgixClientE = ({
     .doL(({ imgixClient }) => {
       imgixClient.includeLibraryParam = false;
       if (options.disableIxlibParam !== true) {
-        (imgixClient as any).settings.libraryParam = `gatsby-source-url-${packageVersion}`;
+        (imgixClient as any).settings.libraryParam = `gatsbySourceUrl-${packageVersion}`;
       }
       return E.right(imgixClient);
     })

--- a/src/modules/gatsby-transform-url/index.ts
+++ b/src/modules/gatsby-transform-url/index.ts
@@ -41,7 +41,7 @@ function buildImageData(
   // This is not a public API, so it is not included in the type definitions for ImgixClient
   if (includeLibraryParam) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (client as any).settings.libraryParam = `gatsby-transform-url-${VERSION}`;
+    (client as any).settings.libraryParam = `gatsbyTransformUrl-${VERSION}`;
   }
 
   const transformedImgixParams = {

--- a/test/unit/source-url/source-url.test.ts
+++ b/test/unit/source-url/source-url.test.ts
@@ -362,7 +362,7 @@ describe('createResolvers', () => {
   describe('ixlib param', () => {
     testForEveryFieldSrcAndSrcSet({
       name: 'should be included in src by default',
-      assertion: (url) => expect(url).toMatch('ixlib=gatsby-source-url'),
+      assertion: (url) => expect(url).toMatch('ixlib=gatsbySourceUrl'),
     });
     testForEveryFieldSrcAndSrcSet({
       name: 'should not exist in src when disableIxlibParam is set',
@@ -371,7 +371,7 @@ describe('createResolvers', () => {
           disableIxlibParam: true,
         },
       },
-      assertion: (url) => expect(url).not.toMatch('ixlib=gatsby-source-url'),
+      assertion: (url) => expect(url).not.toMatch('ixlib=gatsbySourceUrl'),
     });
   });
 

--- a/test/unit/transform-url/transform-url.test.ts
+++ b/test/unit/transform-url/transform-url.test.ts
@@ -11,11 +11,11 @@ import {
 const shouldHaveIxLib = async (
   fut: () => IGatsbyImageFluidData | IGatsbyImageFixedData,
 ) => {
-  test('src and srcset should have ixlib set to gatsby-transform-url-VERSION', async () => {
+  test('src and srcset should have ixlib set to gatsbyTransformUrl-VERSION', async () => {
     const actual = fut();
 
     const expectedIxLibRegex = RegExp(
-      `ixlib=gatsby-transform-url-${(await readPkg()).version}`,
+      `ixlib=gatsbyTransformUrl-${(await readPkg()).version}`,
     );
 
     expect(actual.src).toMatch(expectedIxLibRegex);


### PR DESCRIPTION
This is so that our internal analytics can actually pick up this ixlib. This wasn't working before since our internal spec can only handle one dash.