### PR TITLE
fix: correctly resolve dimensions from resolveWidth and resolveHeight

### DIFF
--- a/src/modules/gatsby-source-url/resolveDimensions.ts
+++ b/src/modules/gatsby-source-url/resolveDimensions.ts
@@ -31,7 +31,7 @@ export const resolveDimensions = <TSource>({
     Error,
     { width: number; height: number }
   > = pipe(
-    sequenceSO({ width: manualHeight, height: manualHeight }),
+    sequenceSO({ width: manualWidth, height: manualHeight }),
     O.fold(
       () => TE.left(new Error(`Couldn't find manual width on obj`)),
       TE.right,

--- a/test/unit/pluginHelpers.test.ts
+++ b/test/unit/pluginHelpers.test.ts
@@ -1,3 +1,6 @@
+import * as fetchImgixMetadataModule from '../../src/api/fetchImgixMetadata';
+import { createImgixGatsbyTypes } from '../../src/pluginHelpers';
+
 // test('should be able to call createImgixUrlFieldConfig with no domain and resolve a url', async () => {
 //   const config = createImgixUrlSchemaFieldConfig({
 //     resolveUrl: (node) => (node as any).url,
@@ -20,13 +23,11 @@
 
 //   expect(resolved).toMatch(/^https:\/\/assets.imgix.net\/amsterdam.jpg\?/);
 // });
+
 describe('plugin helpers', () => {
   describe('resolveWidth and resolveHeight', () => {
     it('should not make a request to imgix when resolveWidth and resolveHeight passed', async () => {
-      const fetchImgixMetadataModule = require('../../src/api/fetchImgixMetadata');
       const spy = jest.spyOn(fetchImgixMetadataModule, 'fetchImgixMetadata');
-
-      const { createImgixGatsbyTypes } = require('../../src/pluginHelpers');
 
       const types = createImgixGatsbyTypes({
         cache: mockGatsbyCache as any,
@@ -49,11 +50,9 @@ describe('plugin helpers', () => {
 
       jest.resetModules();
     });
-    it('should make a request to imgix when resolveWidth and resolveHeight not passed', async () => {
-      const fetchImgixMetadataModule = require('../../src/api/fetchImgixMetadata');
-      const spy = jest.spyOn(fetchImgixMetadataModule, 'fetchImgixMetadata');
 
-      const { createImgixGatsbyTypes } = require('../../src/pluginHelpers');
+    it('should make a request to imgix when resolveWidth and resolveHeight not passed', async () => {
+      const spy = jest.spyOn(fetchImgixMetadataModule, 'fetchImgixMetadata');
 
       const types = createImgixGatsbyTypes({
         cache: mockGatsbyCache as any,
@@ -73,6 +72,43 @@ describe('plugin helpers', () => {
       expect(spy).toBeCalled();
 
       jest.resetModules();
+    });
+
+    it('should resolve dimensions as given', async () => {
+      const width = 200;
+      const height = 100;
+      const aspectRatio = width / height;
+
+      const types = createImgixGatsbyTypes({
+        cache: mockGatsbyCache as any,
+        resolveUrl: () => 'https://assets.imgix.net/amsterdam.jpg',
+        resolveWidth: () => width,
+        resolveHeight: () => height,
+      });
+
+      const fluid = await types.fields.fluid.resolve?.(
+        {},
+        { imgixParams: {} },
+        {},
+        {} as any,
+      );
+      const fixed = await types.fields.fixed.resolve?.(
+        {},
+        { imgixParams: {} },
+        {},
+        {} as any,
+      );
+      const gatsbyImageData = await types.fields.gatsbyImageData.resolve?.(
+        {},
+        { imgixParams: {} },
+        {},
+        {} as any,
+      );
+
+      expect(fluid.aspectRatio).toBe(aspectRatio);
+      expect(fixed.width / fixed.height).toBe(aspectRatio);
+      expect(gatsbyImageData.width).toBe(width);
+      expect(gatsbyImageData.height).toBe(height);
     });
   });
 });


### PR DESCRIPTION
<!-- Hey there! Thanks for contributing to imgix/gatsby! 🎉🙌 Please take a second to fill out PRs with the following template! -->

## Description
Correctly resolves image dimensions when using `resolveWidth` and `resolveHeight` with the plugin helpers.

There is a typo in the code that uses the height for the width, resulting in a 1:1 aspect ratio.

## Checklist: Bug Fix

- [ ] The target branch is `beta`. This is important for our CI/CD config.
- [x] Each commit follows the conventional commit spec format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.
- [x] All existing unit tests are still passing (if applicable)
- [x] Add new passing unit tests to cover the code introduced by your PR
- [ ] Update the readme
- [ ] Update or add any necessary API documentation
- [x] Add some [steps](#steps-to-test) so we can test your bug fix

## Steps to Test

```js
import * as imgixGatsby from '@imgix/gatsby/dist/pluginHelpers'

const types = createImgixGatsbyTypes({
  resolveWidth: (source) => source.width,
  resolveHeight: (source) => source.height,
})
```

Steps:

1.  Use `createImgixGatsbyTypes` to create the necessary types with valid `resolveWidth` and `resolveHeight` functions.
2.  Query for an image in GraphQL
3.  Check the resulting object's aspect ratio.

Before this PR, the aspect ratio was always `1` since it was computing it using `height:height` rather than `width:height`.





<!--

## Conventional Commit Spec

PR titles should be in the format `<type>(<scope>): <description>`. For example: `chore(readme): fix typo`


`type` can be any of the follow:
  - `feat`: a feature, or breaking change
  - `fix`: a bug-fix
  - `test`: Adding missing tests or correcting existing tests
  - `docs`: documentation only changes (readme, changelog, contributing guide)
  - `refactor`: a code change that neither fixes a bug nor adds a feature
  - `chore`: reoccurring tasks for project maintainability (example scopes: release, deps)
  - `config`: changes to tooling configurations used in the project
  - `build`: changes that affect the build system or external dependencies (example scopes: npm, bundler, gradle)
  - `ci`: changes to CI configuration files and scripts (example scopes: travis)
  - `perf`: a code change that improves performance
  - `style`: changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
`scope` is optional, and can be anything.
`description` should be a short description of the change, in the imperative mood.
-->
