### PR TITLE
docs: update npm description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "1.6.3",
   "name": "@imgix/gatsby",
-  "description": "A Gatsby plugin to integrate with imgix's APIs",
+  "description": "The official imgix plugin to apply imgix transformations and optimisations to images in Gatsby at build-time or request-time",
   "author": "Frederick Fogerty <frederick@imgix.com>",
   "license": "BSD-2-Clause",
   "repository": "https://github.com/imgix/gatsby.git",


### PR DESCRIPTION
This PR fixes two issues:

1. Apostrophes don't render correctly on the Gatsby website, so this PR doesn't use apostrophes anymore
![image](https://user-images.githubusercontent.com/615334/118242231-64dcf700-b49d-11eb-90f0-6c68305040eb.png)
2. Added the word "official" to give us more credibility
