### PR TITLE
fix: override w and h params in gatsbyImageData

### DIFF
--- a/src/modules/gatsby-plugin/buildGatsbyImageDataBaseArgs.ts
+++ b/src/modules/gatsby-plugin/buildGatsbyImageDataBaseArgs.ts
@@ -15,9 +15,9 @@ const generateImageSource = (
   opts = {},
 ) => {
   const src = client.buildURL(imageName, {
+    ...(typeof opts.imgixParams === 'object' && opts.imgixParams),
     w: width,
     h: height,
-    ...(typeof opts.imgixParams === 'object' && opts.imgixParams),
   });
   return { width, height, format: 'auto', src };
 };

--- a/test/unit/source-url/source-url.test.ts
+++ b/test/unit/source-url/source-url.test.ts
@@ -491,6 +491,21 @@ describe('createResolvers', () => {
       // Bit flaky here to hard code a colour value, but I wanted to make sure that it was different to the above test
       expect(result.backgroundColor).toMatch('#348ff2');
     });
+
+    it('should override w and h from imgixParams argument', async () => {
+      const imgixParams = { w: 2, h: 1 };
+      const result = await resolveField({
+        field: 'gatsbyImageData',
+        url: 'amsterdam.jpg',
+        fieldParams: {
+          imgixParams,
+        },
+      });
+      const src = new URL(result.images.fallback.src);
+
+      expect(src.searchParams.get('w')).not.toBe(imgixParams.w.toString());
+      expect(src.searchParams.get('h')).not.toBe(imgixParams.h.toString());
+    });
   });
 });
 


### PR DESCRIPTION
<!-- Hey there! Thanks for contributing to imgix/gatsby! 🎉🙌 Please take a second to fill out PRs with the following template! -->

## Description

This PR allows the `gatsbyImageData` field to override `w` and `h` parameters provided by users via the `imgixParams` field argument.

This is necessary to ensure data returned by the field is responsive. In `gatsbyImageData` fields, `w` and `h` parameters do not make sense to prioritize.

This practice is already being done with `fixed` and `fluid` fields.

<!-- 
Please use the checklist that is most closely related to your PR, and delete the other checklists. -->
## Checklist: Bug Fix

- [ ] The target branch is `beta`. This is important for our CI/CD config.
- [x] Each commit follows the conventional commit spec format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.
- [x] All existing unit tests are still passing (if applicable)
- [x] Add new passing unit tests to cover the code introduced by your PR
- [ ] Update the readme
- [ ] Update or add any necessary API documentation
- [ ] Add some [steps](#steps-to-test) so we can test your bug fix

## Steps to Test

1. Query for `gatsbyImageData` with this argument: `imgixParams: { w: 2, h: 1}`.

Without this PR, all URLs in the generated srcSets will have `w=2&h=1`.

With this PR, `w` and `h` will be appropriately set for the srcSet.

Related comment: https://github.com/imgix/gatsby/issues/122#issuecomment-846256825