### PR TITLE
test: don't truncate url at ?

### DIFF
--- a/src/common/uri.ts
+++ b/src/common/uri.ts
@@ -14,7 +14,11 @@ export const parseHostE = (uri: string) =>
 /**
  * Parse the path from a URL. Can fail - for an FP type, use parsePathE
  */
-export const parsePath = (uri: string): string => new Uri(uri).path();
+export const parsePath = (_uri: string): string => {
+  const uri = new Uri(_uri);
+  return uri.path() + uri.query();
+};
+
 export const parsePathE = (uri: string) =>
   E.tryCatch(
     () => parsePath(uri),

--- a/test/unit/transform-url/transform-url.test.ts
+++ b/test/unit/transform-url/transform-url.test.ts
@@ -135,6 +135,19 @@ describe('gatsby-transform-url', () => {
       expect(actual.src).not.toMatch(`fm=webp`);
       expect(actual.srcSet).not.toMatch(`fm=webp`);
     });
+
+    test('should not truncate URL after ?', () => {
+      const actual = buildFixedImageData(
+        'https://test.imgix.net/image.jpg?abc?foo',
+        {
+          w: 1,
+          h: 1,
+        },
+      );
+
+      expect(actual.src).toMatch(`/image.jpg%3Fabc%3Ffoo`);
+      expect(actual.srcSet).toMatch(`/image.jpg%3Fabc%3Ffoo`);
+    });
   });
   describe('buildFluidImageData', () => {
     test('should return an imgix src', () => {
@@ -316,6 +329,18 @@ describe('gatsby-transform-url', () => {
 
       expect(actual.src).not.toMatch(`fm=webp`);
       expect(actual.srcSet).not.toMatch(`fm=webp`);
+    });
+
+    test('should not truncate URL after ?', () => {
+      const actual = buildFluidImageData(
+        'https://test.imgix.net/image.jpg?abc?foo',
+        {
+          ar: 1,
+        },
+      );
+
+      expect(actual.src).toMatch(`/image.jpg%3Fabc%3Ffoo`);
+      expect(actual.srcSet).toMatch(`/image.jpg%3Fabc%3Ffoo`);
     });
   });
 });


### PR DESCRIPTION
Fixes bug identified in #122 where URLs that had a `?` were being truncated. This is incorrect behaviour since we encode `?` as a special parameter and it should not be removed.