### PR TITLE
test: add tests for getGatsbyImageData

### DIFF
--- a/test/unit/transform-url/transform-url.test.ts
+++ b/test/unit/transform-url/transform-url.test.ts
@@ -345,7 +345,7 @@ describe('gatsby-transform-url', () => {
     });
   });
   describe('getGatsbyImageData', () => {
-    it('should return a valid URL', () => {
+    test('should return a valid URL', () => {
       const actual = getGatsbyImageData({
         src: 'https://foo.imgix.com/image.jpg',
         layout: 'fullWidth',
@@ -354,6 +354,16 @@ describe('gatsby-transform-url', () => {
       expect(actual.images.fallback?.src).toMatch(
         'https://foo.imgix.com/image.jpg',
       );
+    });
+
+    test('should not truncate URL after ?', () => {
+      const actual = getGatsbyImageData({
+        src: 'https://test.imgix.net/image.jpg?abc?foo',
+        layout: 'fullWidth',
+        aspectRatio: 1,
+      });
+
+      expect(actual.images.fallback?.src).toMatch(`/image.jpg%3Fabc%3Ffoo`);
     });
   });
 });

--- a/test/unit/transform-url/transform-url.test.ts
+++ b/test/unit/transform-url/transform-url.test.ts
@@ -2,6 +2,7 @@ import readPkg from 'read-pkg';
 import {
   buildFixedImageData,
   buildFluidImageData,
+  getGatsbyImageData,
 } from '../../../src/modules/gatsby-transform-url';
 import {
   IGatsbyImageFixedData,
@@ -341,6 +342,18 @@ describe('gatsby-transform-url', () => {
 
       expect(actual.src).toMatch(`/image.jpg%3Fabc%3Ffoo`);
       expect(actual.srcSet).toMatch(`/image.jpg%3Fabc%3Ffoo`);
+    });
+  });
+  describe('getGatsbyImageData', () => {
+    it('should return a valid URL', () => {
+      const actual = getGatsbyImageData({
+        src: 'https://foo.imgix.com/image.jpg',
+        layout: 'fullWidth',
+        aspectRatio: 1,
+      });
+      expect(actual.images.fallback?.src).toMatch(
+        'https://foo.imgix.com/image.jpg',
+      );
     });
   });
 });


### PR DESCRIPTION
🚨 **NB: this is a stacked PR, so only review [this changeset](https://github.com/imgix/gatsby/pull/128/files/95f82b16d64b08a54b57961db5a3e749a396fc21..c8b2106da28e3b4919a9d2343a1be1edfcf5ebfd), not the full PR**

This function wasn't tested before, so we added a basic test and also a test for the `?` truncation.