### PR TITLE
fix(pe1168): looks like node but missing interface

### DIFF
--- a/src/modules/gatsby-plugin/gatsby-node.ts
+++ b/src/modules/gatsby-plugin/gatsby-node.ts
@@ -141,6 +141,11 @@ export const createSchemaCustomization: ICreateSchemaCustomizationHook<IImgixGat
           fields.map((fieldOptions) =>
             gatsbyContext.schema.buildObjectType({
               name: `${fieldOptions.nodeType}`,
+              // We have to declare that we're extending the Node interface here
+              // This does the same as 'implements Node' does for SDL-defined types.
+              // See here for more info:
+              // https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#:~:text=when%20defining%20top-level%20types%2C%20don%E2%80%99t%20forget%20to%20pass%20interfaces%3A%20%5B'node'%5D%2C%20which%20does%20the%20same%20for%20type%20builders%20as%20adding%20implements%20node%20does%20for%20sdl-defined%20types.%20
+              interfaces: ['Node'],
               fields: {
                 [fieldOptions.fieldName]: {
                   type:


### PR DESCRIPTION
This commit addresses issue #136. 

When extending a type, the plugin can at times fail to determine the original type extended the `Node` interface. This is likely a race condition, where the node we're extending is being created by `buildObjectType` before it's declared to be implementing the Node interface.

This means that our plugin could cause errors to be thrown at build time, as the newly created type was expected to be of type `Node`.

For more information see the Gatsby documentation here:
https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#gatsby-type-builders

> "When defining top-level types, don't forget to pass `interfaces: ['Node']`, which does the same for Type Builders as adding `implements Node` to SDL-defined types."

## Steps to Test

Related issue: #136 

Code:

```Console
warn Type ImagesJson declared in createTypes looks like a node, but doesn't implement a Node interface. It's likely that you should add the Node interface to your type def:
type ImagesJson implements Node { ... }
If you know that you don't want it to be a node (which would mean no root queries to retrieve it), you can explicitly disable inference for it:
type ImagesJson @dontInfer { ... }
ERROR
Building schema failed
not finished building schema - 0.106s
```

Steps:

1.  Go to https://github.com/arsinclair/gatsby-image-schema-bug-reproduction
2.  Clone the repo
3.  run `npm run develop`
4.  See that the error occurs
5. Go to `node_modules/@imgix/gatsby/src/modules/gatsby-plugin/gatsby-node.ts`
6. On line `161` add `interfaces: ["Node"],`
7. See that the build succeeds.
