### PR TITLE
fix: use namespace import for Ramda

### DIFF
--- a/src/modules/gatsby-plugin/createImgixGatsbyImageDataFieldConfig.ts
+++ b/src/modules/gatsby-plugin/createImgixGatsbyImageDataFieldConfig.ts
@@ -18,7 +18,7 @@ import {
   ObjectTypeComposerFieldConfigAsObjectDefinition,
 } from 'graphql-compose';
 import { TypeAsString } from 'graphql-compose/lib/TypeMapper';
-import R from 'ramda';
+import * as R from 'ramda';
 import {
   fetchImgixBase64Image,
   fetchImgixDominantColor,


### PR DESCRIPTION
<!-- Hey there! Thanks for contributing to imgix/gatsby! 🎉🙌 Please take a second to fill out PRs with the following template! -->

## Description

This PR fixes a bug causing `createImgixGatsbyImageDataFieldConfig` to crash when using Gatsby 4 with Deferred Static Generation or Server-Side Rendering.

It uses a namespace import for Ramda rather than a default import. A namespace import was already being used for all other Ramda usage throughout the library.

The following error appears after running `gatsby serve` without the PR:

```
[nix-shell:~/projects/tmp/gatsby-4-prismic-demo]$ yarn serve
yarn run v1.22.10
$ gatsby serve

 ERROR #11321  PLUGIN

"gatsby-source-prismic" threw an error while running the createSchemaCustomization lifecycle:

Cannot read property 'pick' of undefined



  TypeError: Cannot read property 'pick' of undefined

  - index.js:296774 Object.createImgixGatsbyImageFieldConfig
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:296774:110

  - index.js:271751 Object.buildImgixGatsbyTypes
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:271751:74

  - index.js:269445 Object.createImgixGatsbyTypes
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:269445:26

  - index.js:246900
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:246900:164

  - index.js:254064
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:254064:103

  - index.js:254180
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:254180:151

  - index.js:254970
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:254970:116

  - index.js:255172
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:255172:44




 ERROR

UNHANDLED REJECTION Type with name "ImgixParamsInput" does not exists



  Error: Type with name "ImgixParamsInput" does not exists

  - index.js:124299 SchemaComposer.get
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:124299:13

  - index.js:125253
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:125253:47

  - Array.forEach

  - index.js:125229 TypeMapper.makeArguments
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:125229:12

  - index.js:125275
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:125275:20

  - index.js:59561
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:59561:24

  - Array.reduce

  - index.js:59560 keyValMap
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:59560:15

  - index.js:125271 TypeMapper.makeFieldDefMap
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:125271:82

  - index.js:125505 TypeMapper.makeTypeDef
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:125505:20

  - index.js:125172 TypeMapper.makeSchemaDef
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:125172:21

  - index.js:208667
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:208667:52

  - Array.forEach

  - index.js:208634 parseTypes
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:208634:19

  - index.js:207677
    /[path-to-project]/gatsby-4-prismic-demo/.cache/query-engine/index.js:207677:23

  - Array.forEach



error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

<!-- 
Please use the checklist that is most closely related to your PR, and delete the other checklists. -->

## Checklist: Bug Fix

- [ ] The target branch is `beta`. This is important for our CI/CD config.
- [x] Each commit follows the conventional commit spec format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.
- [ ] All existing unit tests are still passing (if applicable)
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Update the readme
- [ ] Update or add any necessary API documentation
- [ ] Add some [steps](#steps-to-test) so we can test your bug fix

## Steps to Test

Steps:

1.  Clone https://github.com/angeloashmore/gatsby-4-prismic-demo
2.  Add `defer: true` to `createPage` in `gatsby-node.js`

    ```js
    createPage({
      path: page.url,
      component: path.resolve(__dirname, "src/templates/page.tsx"),
      context: { id: page.id },
      defer: true,
    });
    ```

3.  Build the site: `yarn build`
4.  Serve the site: `yarn serve`





<!--

## Conventional Commit Spec

PR titles should be in the format `<type>(<scope>): <description>`. For example: `chore(readme): fix typo`


`type` can be any of the follow:
  - `feat`: a feature, or breaking change
  - `fix`: a bug-fix
  - `test`: Adding missing tests or correcting existing tests
  - `docs`: documentation only changes (readme, changelog, contributing guide)
  - `refactor`: a code change that neither fixes a bug nor adds a feature
  - `chore`: reoccurring tasks for project maintainability (example scopes: release, deps)
  - `config`: changes to tooling configurations used in the project
  - `build`: changes that affect the build system or external dependencies (example scopes: npm, bundler, gradle)
  - `ci`: changes to CI configuration files and scripts (example scopes: travis)
  - `perf`: a code change that improves performance
  - `style`: changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
`scope` is optional, and can be anything.
`description` should be a short description of the change, in the imperative mood.
-->
