### PR TITLE
fix: support URLs with hash symbol

### DIFF
--- a/src/common/uri.ts
+++ b/src/common/uri.ts
@@ -16,7 +16,7 @@ export const parseHostE = (uri: string) =>
  */
 export const parsePath = (_uri: string): string => {
   const uri = new Uri(_uri);
-  return uri.path() + uri.query();
+  return uri.path() + uri.query() + (uri.anchor() ? `#${uri.anchor()}` : '');
 };
 
 export const parsePathE = (uri: string) =>


### PR DESCRIPTION
<!-- Hey there! Thanks for contributing to imgix/gatsby! 🎉🙌 Please take a second to fill out PRs with the following template! -->

## Description

This PR fixes the `parsePath` function to support URLs containing a hash symbol. For example, a URL that looks like this:

```
https://example.net/image-#1.png
```

Without this fix, the plugin will strip everything after `#`, resulting in something like the following:

```
https://example.net/image-?ixlib=gatsbyFP
```


<!-- 
Please use the checklist that is most closely related to your PR, and delete the other checklists. -->
## Checklist: Fixing typos/Doc change

- [ ] The target branch is `beta`. This is important for our CI/CD config.
- [x] Each commit follows the conventional commit spec format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.

## Checklist: Bug Fix

- [ ] The target branch is `beta`. This is important for our CI/CD config.
- [x] Each commit follows the conventional commit spec format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.
- [ ] All existing unit tests are still passing (if applicable)
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Update the readme
- [ ] Update or add any necessary API documentation
- [ ] Add some [steps](#steps-to-test) so we can test your bug fix

