### PR TITLE
chore: update gatsby-plugin-image peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "gatsby": "^2 || ^3 || ^4",
     "gatsby-image": "^2 || ^3",
-    "gatsby-plugin-image": "^1"
+    "gatsby-plugin-image": "^1 || ^2"
   },
   "resolutions": {
     "graphql": "15.5.0",


### PR DESCRIPTION
Updates project peer dependencies to include version ^2 of gatsby-plugin-image. Verified compatibility in https://github.com/sherwinski/gatsby-v4-imgix-demo