### PR TITLE
fix: "cannot read properties of undefined (reading 'pick')" error

### DIFF
--- a/src/common/ar.ts
+++ b/src/common/ar.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts';
-import * as R from 'ramda';
+import { pipe, map } from 'ramda';
 import { roundToDP } from './number';
 interface AspectRatioBrand {
   readonly StringAspectRatio: unique symbol;
@@ -23,9 +23,9 @@ function aspectRatioIsValid(aspectRatio: string): boolean {
   return /^\d+(\.\d+)?:\d+(\.\d+)?$/.test(aspectRatio);
 }
 export const parseStringARParam = (ar: StringAspectRatio): number =>
-  R.pipe(
+  pipe(
     (v: StringAspectRatio) => v.split(':') as [string, string],
-    R.map((part) => parseFloat(part)),
+    map((part) => parseFloat(part)),
     ([width, height]) => width / height,
     (v) => roundToDP(3, v),
   )(ar);

--- a/src/modules/gatsby-plugin/createImgixGatsbyImageDataFieldConfig.ts
+++ b/src/modules/gatsby-plugin/createImgixGatsbyImageDataFieldConfig.ts
@@ -18,7 +18,7 @@ import {
   ObjectTypeComposerFieldConfigAsObjectDefinition,
 } from 'graphql-compose';
 import { TypeAsString } from 'graphql-compose/lib/TypeMapper';
-import * as R from 'ramda';
+import { pick } from 'ramda';
 import {
   fetchImgixBase64Image,
   fetchImgixDominantColor,
@@ -194,7 +194,7 @@ export const createImgixGatsbyImageFieldConfig = <TSource, TContext = {}>({
   const modifiedConfig = {
     ...defaultConfig,
     args: {
-      ...R.pick(
+      ...pick(
         [
           'layout',
           'width',

--- a/src/modules/gatsby-plugin/createImgixUrlFieldConfig.ts
+++ b/src/modules/gatsby-plugin/createImgixUrlFieldConfig.ts
@@ -5,7 +5,7 @@ import {
   ComposeInputTypeDefinition,
   ObjectTypeComposerFieldConfigAsObjectDefinition,
 } from 'graphql-compose';
-import * as R from 'ramda';
+import { mergeRight } from 'ramda';
 import { createExternalHelper } from '../../common/createExternalHelper';
 import { IImgixURLBuilder } from '../../common/imgix-js-core-wrapper';
 import {
@@ -53,7 +53,7 @@ export const createImgixUrlFieldConfig = <TSource, TContext>({
       TE.map((url) =>
         imgixClient.buildURL(
           url,
-          R.mergeRight(
+          mergeRight(
             defaultParams ?? {},
             unTransformParams(args.imgixParams ?? {}),
           ),

--- a/src/modules/gatsby-plugin/gatsby-node.ts
+++ b/src/modules/gatsby-plugin/gatsby-node.ts
@@ -4,7 +4,7 @@ import { pipe } from 'fp-ts/pipeable';
 import { ICreateSchemaCustomizationHook, PatchedPluginOptions } from 'gatsby';
 import { GraphQLNonNull, GraphQLString } from 'gatsby/graphql';
 import { PathReporter } from 'io-ts/PathReporter';
-import * as R from 'ramda';
+import { prop } from 'ramda';
 import { IImgixGatsbyOptions, ImgixSourceType } from '../..';
 import { VERSION } from '../../common/constants';
 import {
@@ -120,7 +120,7 @@ export const createSchemaCustomization: ICreateSchemaCustomizationHook<IImgixGat
           buildImgixGatsbyTypes<{ rawURL: string }>({
             cache: gatsbyContext.cache,
             imgixClient,
-            resolveUrl: R.prop('rawURL'),
+            resolveUrl: prop('rawURL'),
             defaultParams: defaultImgixParams,
           }),
       )

--- a/src/modules/gatsby-plugin/objectBuilders.ts
+++ b/src/modules/gatsby-plugin/objectBuilders.ts
@@ -1,5 +1,5 @@
 import { FixedObject, FluidObject } from 'gatsby-image';
-import * as R from 'ramda';
+import { pipe, split, head } from 'ramda';
 import { IImgixURLBuilder } from '../../common/imgix-js-core-wrapper';
 import { log, trace } from '../../common/log';
 import { IImgixParams, ImgixUrlParams } from '../../publicTypes';
@@ -15,12 +15,11 @@ export type BuildImgixFluidArgs = {
   defaultPlaceholderParams?: Partial<IImgixParams>;
 };
 
-const parseAspectRatioFloatFromString = R.pipe<
-  string,
-  string[],
-  string,
-  number
->(R.split(':'), R.head, (v) => parseInt(v));
+const parseAspectRatioFloatFromString = pipe<string, string[], string, number>(
+  split(':'),
+  head,
+  (v) => parseInt(v),
+);
 
 const DEFAULT_LQIP_PARAMS: ImgixUrlParams = { w: 20, blur: 15, q: 20 };
 

--- a/src/modules/gatsby-transform-url/gatsbyPluginImageComponent.tsx
+++ b/src/modules/gatsby-transform-url/gatsbyPluginImageComponent.tsx
@@ -1,5 +1,5 @@
 import { GatsbyImage, GatsbyImageProps } from 'gatsby-plugin-image';
-import * as R from 'ramda';
+import { pick, omit } from 'ramda';
 import React from 'react';
 import {
   GATSBY_IMAGE_HOOK_OPTS_KEYS,
@@ -8,8 +8,8 @@ import {
 
 export const ImgixGatsbyImage = (props: IImgixGatsbyImageProps) => {
   // split into two groups of props, one for hook and one for comp.
-  const hookProps = R.pick(GATSBY_IMAGE_HOOK_OPTS_KEYS, props);
-  const imageProps = R.omit(GATSBY_IMAGE_HOOK_OPTS_KEYS, props);
+  const hookProps = pick(GATSBY_IMAGE_HOOK_OPTS_KEYS, props);
+  const imageProps = omit(GATSBY_IMAGE_HOOK_OPTS_KEYS, props);
 
   const data = getGatsbyImageData(hookProps);
 

--- a/src/publicTypes.ts
+++ b/src/publicTypes.ts
@@ -1,5 +1,5 @@
 import imgixUrlParameters from 'imgix-url-params/dist/parameters.json';
-import * as R from 'ramda';
+import { mapObjIndexed } from 'ramda';
 import * as t from './common/ioTs';
 
 export enum ImgixSourceType {
@@ -31,7 +31,7 @@ const ImgixParamValueIOTS = t.union(
 const mapToImgixParamValue = <TKey extends string>(
   obj: Record<TKey, unknown>,
 ): Record<TKey, typeof ImgixParamValueIOTS> =>
-  R.mapObjIndexed(() => ImgixParamValueIOTS, obj);
+  mapObjIndexed(() => ImgixParamValueIOTS, obj);
 
 const ImgixParamsIOTS = t.partial(
   {

--- a/test/common/getSrcsetWidths.ts
+++ b/test/common/getSrcsetWidths.ts
@@ -1,8 +1,8 @@
-import * as R from 'ramda';
-export const getSrcsetWidths: (srcset: string) => number[] = R.pipe(
-  R.split(','),
-  R.map(R.trim),
-  R.map(R.split(' ')),
-  R.map<readonly string[], string>(R.last),
-  R.map(parseInt),
+import { pipe, split, map, last, trim } from 'ramda';
+export const getSrcsetWidths: (srcset: string) => number[] = pipe(
+  split(','),
+  map(trim),
+  map(split(' ')),
+  map<readonly string[], string>(last),
+  map(parseInt),
 );

--- a/test/dev-and-e2e/gatsby-config.js
+++ b/test/dev-and-e2e/gatsby-config.js
@@ -1,7 +1,5 @@
 const { ImgixSourceType } = require("@imgix/gatsby")
 
-require("dotenv").config()
-
 module.exports = {
   siteMetadata: {
     title: `Gatsby Default Starter`,

--- a/test/dev-and-e2e/gatsby-config.js
+++ b/test/dev-and-e2e/gatsby-config.js
@@ -1,5 +1,7 @@
 const { ImgixSourceType } = require("@imgix/gatsby")
 
+require("dotenv").config()
+
 module.exports = {
   siteMetadata: {
     title: `Gatsby Default Starter`,
@@ -33,7 +35,7 @@ module.exports = {
     {
       resolve: `@imgix/gatsby`,
       options: {
-        domain: "sdk-proxy-test.imgix.net",
+        domain: "prismic-angeloashmore.imgix.net",
         secureURLToken: process.env.PROXY_DEMO_TOKEN,
         sourceType: ImgixSourceType.WebProxy,
         fields: [

--- a/test/dev-and-e2e/gatsby-config.js
+++ b/test/dev-and-e2e/gatsby-config.js
@@ -35,7 +35,7 @@ module.exports = {
     {
       resolve: `@imgix/gatsby`,
       options: {
-        domain: "prismic-angeloashmore.imgix.net",
+        domain: "sdk-proxy-test.imgix.net",
         secureURLToken: process.env.PROXY_DEMO_TOKEN,
         sourceType: ImgixSourceType.WebProxy,
         fields: [


### PR DESCRIPTION
<!-- Hey there! Thanks for contributing to imgix/gatsby! 🎉🙌 Please take a second to fill out PRs with the following template! -->

## Description
<!-- What is accomplished by this PR? If there is something potentially controversial in your PR, please take a moment to tell us about your choices. -->

This PR fixes an error thrown when building sites using Gatsby 4 by only using Ramda with named imports. See this issue: https://github.com/prismicio/prismic-gatsby/issues/488

I have recreated the issue by using Gatsby 4's [Deferred Static Generation](https://www.gatsbyjs.com/docs/how-to/rendering-options/using-deferred-static-generation/) feature. The linked issue reports that the error is also thrown in non-DSG sites, however.

It appears to be an issue in the way Gatsby bundles code for its standalone GraphQL query server. The Ramda `*` import seems to use the `default` export after bundling. I don't know why this happens, but changing to named imports circumvents the issue.

<!-- 
Please use the checklist that is most closely related to your PR, and delete the other checklists. -->
## Checklist: Fixing typos/Doc change

- [ ] The target branch is `beta`. This is important for our CI/CD config.
- [x] Each commit follows the conventional commit spec format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.

## Checklist: Bug Fix

- [ ] The target branch is `beta`. This is important for our CI/CD config.
- [x] Each commit follows the conventional commit spec format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.
- [x] All existing unit tests are still passing (if applicable)
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Update the readme
- [ ] Update or add any necessary API documentation
- [ ] Add some [steps](#steps-to-test) so we can test your bug fix

