### PR TITLE
chore: release v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### [1.7.6-rc.2](https://github.com/imgix/gatsby/compare/v1.7.6-rc.1...v1.7.6-rc.2) (2022-02-25)
+
 ### [1.7.6-rc.1](https://github.com/imgix/gatsby/compare/v1.7.5...v1.7.6-rc.1) (2022-02-14)
 
 This release improves support for Gatsby v4. As a result, the configuration for this plugin will need to be updated. This should be in most cases just a simple update. Instructions for this change can be found in the README under ["Upgrading from v1.x to v2"](./README.md#upgrading-from-v1x-to-v2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ### [1.7.6-rc.1](https://github.com/imgix/gatsby/compare/v1.7.5...v1.7.6-rc.1) (2022-02-14)
 
+This release improves support for Gatsby v4. As a result, the configuration for this plugin will need to be updated. This should be in most cases just a simple update. Instructions for this change can be found in the README under ["Upgrading from v1.x to v2"](./README.md#upgrading-from-v1x-to-v2).
+
 
 ### ⚠ BREAKING CHANGES
 
-* change getURL config from function to string
+* The `getURL` config option was changed from a function to a string. Instructions to migrate this can be found in the README under ["Upgrading from v1.x to v2"](./README.md#upgrading-from-v1x-to-v2). This change was made since this config option did not work for DSG and SSR pages.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### [1.7.6-rc.1](https://github.com/imgix/gatsby/compare/v1.7.5...v1.7.6-rc.1) (2022-02-14)
+
+
+### ⚠ BREAKING CHANGES
+
+* change getURL config from function to string
+
+### Features
+
+* change getURL config from function to string ([0844948](https://github.com/imgix/gatsby/commit/0844948c022514926bdef864902d056adb8a5236))
+
 ### [1.7.5](https://github.com/imgix/gatsby/compare/v1.7.4...v1.7.5) (2022-01-11)
 
 

--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@
     * [What section should I read?](#what-section-should-i-read)
     * [GraphQL transform API](#graphql-transform-api)
         + [Configuration](#configuration)
-        + [✨ New ✨ GatsbyImage support](#-new--gatsbyimage-support)
+        + [✨ New ✨ GatsbyImage support](#%E2%9C%A8-new-%E2%9C%A8-gatsbyimage-support)
         + [Fluid Images](#fluid-images)
         + [Fixed Images](#fixed-images)
         + [Generating imgix URLs](#generating-imgix-urls)
     * [GraphQL `imgixImage` API](#graphql-imgiximage-api)
         + [Configuration](#configuration-1)
-        + [✨ New ✨ GatsbyImage support](#-new--gatsbyimage-support-1)
+        + [✨ New ✨ GatsbyImage support](#%E2%9C%A8-new-%E2%9C%A8-gatsbyimage-support-1)
         + [Fluid Images](#fluid-images-1)
         + [Fixed Images](#fixed-images-1)
         + [Generating imgix URLs](#generating-imgix-urls-1)
         + [Using a Web Proxy Source](#using-a-web-proxy-source)
     * [URL Transform Function](#url-transform-function)
-        + [✨ New ✨ Gatsby-plugin-image Component and Hook](#-new--gatsby-plugin-image-component-and-hook)
+        + [✨ New ✨ Gatsby-plugin-image Component and Hook](#%E2%9C%A8-new-%E2%9C%A8-gatsby-plugin-image-component-and-hook)
         + [Basic Fluid Image](#basic-fluid-image)
         + [Basic Fixed Image](#basic-fixed-image)
 - [API](#api)
@@ -60,7 +60,9 @@
     * [GraphQL Type Customization Warning](#graphql-type-customization-warning)
     * [Multiple imgix Sources](#multiple-imgix-sources)
 - [Roadmap](#roadmap)
-- [Upgrading from `@imgix/gatsby-transform-url`](#upgrading-from-imgixgatsby-transform-url)
+- [Upgrade Guides](#upgrade-guides)
+    * [Upgrading from v1.x to v2](#upgrading-from-v1x-to-v2)
+    * [Upgrading from `@imgix/gatsby-transform-url`](#upgrading-from-imgixgatsby-transform-url)
 - [Contributors](#contributors)
 - [License](#license)
 
@@ -270,7 +272,7 @@ The steps to setting this value correctly is:
    }
    ```
 
-   Therefore, we need to set the option to `file.url`, to return the url at `node.file.url`.
+   Therefore, we need to set the option to `file.url`, to return the url at `node.file.url`. NB: the value for `rawURLKey` is passed to `lodash.get`, so array indices, etc can also be used if necessary.
 
 3. Set the option to the correct value, **making sure that the URL includes an http or https.** For this example, since the image URL didn't have a `https`, we have to add `https` to the `URLPrefix` option:
 
@@ -1213,7 +1215,43 @@ Other features:
 
 - [I want to have my imgix parameters in my Gatsby/GraphQL query be strongly-typed](https://github.com/imgix/gatsby/issues/5)
 
-## Upgrading from `@imgix/gatsby-transform-url`
+## Upgrade Guides
+
+### Upgrading from v1.x to v2
+
+Between v1 and v2, the method to retrieve the image url in the GraphQL from the raw data was changed. This was done to support Gatsby v4, as function configuration options are no longer possible in Gatsby v4. If you do not use the GraphQL transform API, then you do not have to change anything.
+
+To upgrade from v1 to v2, the following configuration options need to be updated:
+
+```jsx
+// gatsby-config.js
+module.exports = {
+  plugins: {
+    // ...
+    {
+      resolve: `@imgix/gatsby`,
+      options: {
+        // ...
+        fields: [
+          {
+            nodeType: "Post",
+            fieldName: "imgixImage",
+
+            // The follow option needs to be changed...
+            getURL: node => `https:${node.banner.imageURL}`,
+
+            // to this:
+            rawURLKey: "banner.imageURL",
+            URLPrefix: "https:",
+          },
+        ],
+      },
+    },
+  }
+}
+```
+
+### Upgrading from `@imgix/gatsby-transform-url`
 
 `@imgix/gatsby-transform-url` was deprecated in favor of combining these sub-projects into one single project, for simplicity.
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ Then, you need to configure a field for this node type. The quickest way to conf
 {
   nodeType: "ContentfulAsset",
   fieldName: "imgixImage",
-  getURL: node => `https:${node.file.url}`
+  rawURLKey: 'file.url',
+  URLPrefix: 'https:',
 },
 ```
 
@@ -186,7 +187,7 @@ Then, you need to configure a field for this node type. The quickest way to conf
 ```js
 {
   nodeType: "DatoCmsAsset",
-  getURL: node => node.entityPayload.attributes.url,
+  rawURLKey: 'entityPayload.attributes.url',
   fieldName: "imgixImage",
 },
 ```
@@ -197,7 +198,7 @@ Then, you need to configure a field for this node type. The quickest way to conf
 // Drupal
 {
   nodeType: 'File',
-  getURL: (node) => node.url,
+  rawURLKey: (node) => node.url,
   fieldName: 'imgixImage',
 },
 ```
@@ -211,26 +212,24 @@ Then, you need to configure a field for this node type. The quickest way to conf
   nodeType: '',
 
   // This is used to pull the raw image URL from the node you want to
-  // transform. It is passed the node to transform as an argument, and
-  // expects a URL to be returned.
+  // transform. The value here should be the path in the node that 
+  // contains the image URL to be transformed.
   // See more information below on how to set this.
-  getURL: (node) => node.imageUrl,
+  rawURLKey: 'imageUrlKey',
 
   // This is the name of imgix field that will be added to the type.
   fieldName: 'imgixImage',
 },
 ```
 
-The `getURL` function needs to return a **fully-qualified URL**.
+The `rawURLKey` value needs to be the path to the raw image URL in the node data that should be transformed.
 
 The steps to setting this value correctly is:
 
-1. Set the function to this:
+1. Set the option to:
 
    ```js
-   getURL: (node) => {
-     console.log(node);
-   };
+   rawURLKey: ''
    ```
 
 2. Inspect the logged output. The plugin will try to find a suitable image url in the node's data for you, and if it successfully finds one, it will output the code to replace the function with in the corresponding error message.
@@ -238,20 +237,22 @@ The steps to setting this value correctly is:
    For example, for `ContentfulAsset`, it will display the following error message:
 
    ```txt
-   Error when resolving URL value for node type ContentfulAsset. This
-   probably means that the getURL function in gatsby-config.js is
-   incorrectly set. Please read this project's README for detailed
-   instructions on how to set this correctly.
+   Error when resolving URL value for node type Post. This probably means that
+   the rawURLKey function in gatsby-config.js is incorrectly set. Please read this
+   project's README for detailed instructions on how to set this correctly.
 
    Potential images were found at these paths:
-    - file.url
-      Usage: getURL: (node) => `https:${node.file.url}`
+     - imageURL
+       Set following configuration options:
+         rawURLKey: 'imageURL'
+         URLPrefix: 'https:'
    ```
 
-   As we can see, the correct value for the function is
+   As we can see, the correct value for the options are
 
    ```js
-   getURL: (node) => `https:${node.file.url}
+   rawURLKey: 'imageURL',
+   URLPrefix: 'https:'
    ```
 
    If no value was suggested, you will need to inspect the logged output to find a suitable image URL that corresponds to the image you want to transform. For example, if we're searching ContentfulAsset's data, we see the following output in the console:
@@ -269,12 +270,13 @@ The steps to setting this value correctly is:
    }
    ```
 
-   Therefore, we need to return `file.url`.
+   Therefore, we need to set the option to `file.url`, to return the url at `node.file.url`.
 
-3. Set the function to the correct value, **making sure that the URL includes an http or https.** For this example, since the image URL didn't have a `https`, we have to add one:
+3. Set the option to the correct value, **making sure that the URL includes an http or https.** For this example, since the image URL didn't have a `https`, we have to add `https` to the `URLPrefix` option:
 
    ```js
-   getURL: (node) => `https:${node.file.url}`;
+   rawURLKey: 'file.url`,
+   URLPrefix: 'https:'
    ```
 
 ##### Finding a node's type

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Then, you need to configure a field for this node type. The quickest way to conf
   nodeType: '',
 
   // This is used to pull the raw image URL from the node you want to
-  // transform. The value here should be the path in the node that 
+  // transform. The value here should be the path in the node that
   // contains the image URL to be transformed.
   // See more information below on how to set this.
   rawURLKey: 'imageUrlKey',
@@ -229,7 +229,7 @@ The steps to setting this value correctly is:
 1. Set the option to:
 
    ```js
-   rawURLKey: ''
+   rawURLKey: '';
    ```
 
 2. Inspect the logged output. The plugin will try to find a suitable image url in the node's data for you, and if it successfully finds one, it will output the code to replace the function with in the corresponding error message.

--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@
     * [What section should I read?](#what-section-should-i-read)
     * [GraphQL transform API](#graphql-transform-api)
         + [Configuration](#configuration)
-        + [✨ New ✨ GatsbyImage support](#%E2%9C%A8-new-%E2%9C%A8-gatsbyimage-support)
+        + [GatsbyImage support](#gatsbyimage-support)
         + [Fluid Images](#fluid-images)
         + [Fixed Images](#fixed-images)
         + [Generating imgix URLs](#generating-imgix-urls)
     * [GraphQL `imgixImage` API](#graphql-imgiximage-api)
         + [Configuration](#configuration-1)
-        + [✨ New ✨ GatsbyImage support](#%E2%9C%A8-new-%E2%9C%A8-gatsbyimage-support-1)
+        + [GatsbyImage support](#gatsbyimage-support-1)
         + [Fluid Images](#fluid-images-1)
         + [Fixed Images](#fixed-images-1)
         + [Generating imgix URLs](#generating-imgix-urls-1)
         + [Using a Web Proxy Source](#using-a-web-proxy-source)
     * [URL Transform Function](#url-transform-function)
-        + [✨ New ✨ Gatsby-plugin-image Component and Hook](#%E2%9C%A8-new-%E2%9C%A8-gatsby-plugin-image-component-and-hook)
+        + [Gatsby-plugin-image Component and Hook](#gatsby-plugin-image-component-and-hook)
         + [Basic Fluid Image](#basic-fluid-image)
         + [Basic Fixed Image](#basic-fixed-image)
 - [API](#api)
@@ -297,7 +297,7 @@ It's also possible to add `__typeName` to the GraphQL query to find the node typ
 
 Setting `auto: ['format', 'compress']` is highly recommended. This will re-format the image to the format that is best optimized for your browser, such as WebP. It will also reduce unnecessary wasted file size, such as transparency on a non-transparent image. More information about the auto parameter can be found [here](https://docs.imgix.com/apis/url/auto/auto).
 
-#### ✨ New ✨ GatsbyImage support
+#### GatsbyImage support
 
 This plugin now supports the latest `GatsbyImage` component, which delivers better performance and Lighthouse scores, while improving the developer experience.
 
@@ -489,7 +489,7 @@ module.exports = {
 
 Setting `{ auto: ['compress', 'format'] }` is highly recommended. This will re-format the image to the format that is best optimized for your browser, such as WebP. It will also reduce unnecessary wasted file size, such as transparency on a non-transparent image. More information about the auto parameter can be found [here](https://docs.imgix.com/apis/url/auto/auto).
 
-#### ✨ New ✨ GatsbyImage support
+#### GatsbyImage support
 
 This plugin now supports the latest `GatsbyImage` component, which delivers better performance and Lighthouse scores, while improving the developer experience.
 
@@ -673,7 +673,7 @@ This features allows imgix urls to be used with gatsby-image or gatsby-plugin-im
 
 Unfortunately, due to limitations of Gatsby, this feature does not support blurred placeholders. To use placeholders please use one of the other use cases/parts of this library
 
-#### ✨ New ✨ Gatsby-plugin-image Component and Hook
+#### Gatsby-plugin-image Component and Hook
 
 This plugin supports the new frontend Gatsby-plugin-image component. To use the component with this plugin, use the following code
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "io-ts": "^2.2.13",
     "io-ts-reporters": "^1.2.2",
     "jsuri": "^1.3.1",
+    "lodash.get": "^4.4.2",
     "node-fetch": "^2.6.0",
     "ramda": "^0.27.1",
     "read-pkg-up": "^7.0.1"
@@ -69,6 +70,7 @@
     "@types/is-base64": "1.1.1",
     "@types/jest": "27.4.0",
     "@types/jsuri": "1.3.30",
+    "@types/lodash.get": "^4.4.6",
     "@types/node-fetch": "2.5.12",
     "@types/ramda": "0.27.44",
     "babel-eslint": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.6-rc.1",
+  "version": "1.7.6-rc.2",
   "name": "@imgix/gatsby",
   "description": "The official imgix plugin to apply imgix transformations and optimisations to images in Gatsby at build-time or request-time",
   "author": "Frederick Fogerty <frederick@imgix.com>",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.5",
+  "version": "1.7.6-rc.1",
   "name": "@imgix/gatsby",
   "description": "The official imgix plugin to apply imgix transformations and optimisations to images in Gatsby at build-time or request-time",
   "author": "Frederick Fogerty <frederick@imgix.com>",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.7.6-rc.1';
+export const VERSION = '1.7.6-rc.2';

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.7.5';
+export const VERSION = '1.7.6-rc.1';

--- a/src/modules/gatsby-plugin/gatsby-node.ts
+++ b/src/modules/gatsby-plugin/gatsby-node.ts
@@ -44,7 +44,9 @@ const getFieldValue = ({
         fieldOptions.rawURLKeys.map((rawURLKey) => get(node, rawURLKey)),
         (value: unknown) =>
           !isStringArray(value)
-            ? E.left(new Error('rawURLKeys must reference a list of URL strings'))
+            ? E.left(
+                new Error('rawURLKeys must reference a list of URL strings'),
+              )
             : E.right(value.map(prefixURLPrefix)),
       );
     }

--- a/src/publicTypes.ts
+++ b/src/publicTypes.ts
@@ -47,28 +47,21 @@ export interface IBaseFieldOptions {
   fieldName: string;
 }
 
-export interface IFieldOptionsSingleUrl extends IBaseFieldOptions {
-  getUrl: (node: Node) => string;
-}
-
-export interface IFieldOptionsMultipleUrls extends IBaseFieldOptions {
-  getUrls: (node: Node) => string;
-}
-
-const ImgixGatsbyFieldBaseIOTS = t.type({
+const ImgixGatsbyFieldBaseIOTS = t.typeOptional({
   nodeType: t.string,
   fieldName: t.string,
+  URLPrefix: t.optional(t.string),
 });
 export const ImgixGatsbyFieldMultipleUrlsIOTS = t.intersection([
   ImgixGatsbyFieldBaseIOTS,
   t.type({
-    getURLs: t.Function,
+    getURLs: t.array(t.string),
   }),
 ]);
 export const ImgixGatsbyFieldSingleUrlIOTS = t.intersection([
   ImgixGatsbyFieldBaseIOTS,
   t.type({
-    getURL: t.Function,
+    getURL: t.string,
   }),
 ]);
 export const ImgixGatsbyFieldsIOTS = t.array(
@@ -123,5 +116,3 @@ export interface ImgixFixedArgs {
   imgixParams?: ImgixUrlParams;
   placeholderImgixParams?: ImgixUrlParams;
 }
-
-export type IFieldOption = IFieldOptionsSingleUrl | IFieldOptionsMultipleUrls;

--- a/src/publicTypes.ts
+++ b/src/publicTypes.ts
@@ -55,13 +55,13 @@ const ImgixGatsbyFieldBaseIOTS = t.typeOptional({
 export const ImgixGatsbyFieldMultipleUrlsIOTS = t.intersection([
   ImgixGatsbyFieldBaseIOTS,
   t.type({
-    getURLs: t.array(t.string),
+    rawURLKeys: t.array(t.string),
   }),
 ]);
 export const ImgixGatsbyFieldSingleUrlIOTS = t.intersection([
   ImgixGatsbyFieldBaseIOTS,
   t.type({
-    getURL: t.string,
+    rawURLKey: t.string,
   }),
 ]);
 export const ImgixGatsbyFieldsIOTS = t.array(

--- a/test/dev-and-e2e/gatsby-config.js
+++ b/test/dev-and-e2e/gatsby-config.js
@@ -40,7 +40,7 @@ module.exports = {
           {
             nodeType: "Post",
             fieldName: "imgixImage",
-            rawURLKey: "node.imageURL",
+            rawURLKey: "imageURL",
             URLPrefix: "https:",
           },
         ],

--- a/test/dev-and-e2e/gatsby-config.js
+++ b/test/dev-and-e2e/gatsby-config.js
@@ -40,7 +40,7 @@ module.exports = {
           {
             nodeType: "Post",
             fieldName: "imgixImage",
-            getURL: "node.imageURL",
+            rawURLKey: "node.imageURL",
             URLPrefix: "https:",
           },
         ],

--- a/test/dev-and-e2e/gatsby-config.js
+++ b/test/dev-and-e2e/gatsby-config.js
@@ -40,7 +40,8 @@ module.exports = {
           {
             nodeType: "Post",
             fieldName: "imgixImage",
-            getURL: node => node.imageURL,
+            getURL: "node.imageURL",
+            URLPrefix: "https:",
           },
         ],
       },

--- a/test/dev-and-e2e/gatsby-node.js
+++ b/test/dev-and-e2e/gatsby-node.js
@@ -39,7 +39,7 @@ exports.sourceNodes = async ({
   // Data can come from anywhere, but for now create it manually
   const testData = {
     key: 123,
-    imageURL: "https://assets.imgix.net/amsterdam.jpg",
+    imageURL: "//assets.imgix.net/amsterdam.jpg",
   }
   const nodeContent = JSON.stringify(testData)
   const node = {

--- a/test/unit/source-url/source-url.test.ts
+++ b/test/unit/source-url/source-url.test.ts
@@ -7,7 +7,7 @@ import { FixedObject, FluidObject } from 'gatsby-image';
 import {
   buildEnumType,
   buildInputObjectType,
-  buildObjectType,
+  buildObjectType
 } from 'gatsby/dist/schema/types/type-builders';
 import isBase64 from 'is-base64';
 import * as R from 'ramda';
@@ -506,6 +506,56 @@ describe('createResolvers', () => {
       expect(src.searchParams.get('w')).not.toBe(imgixParams.w.toString());
       expect(src.searchParams.get('h')).not.toBe(imgixParams.h.toString());
     });
+  });
+  it('should accept string path for getURL', async () => {
+    const result = await getTypeStoreFromSchemaCustomization({
+      appConfig: {
+        fields: [
+          {
+            nodeType: 'ImgixImageTest',
+            fieldName: 'imgixImage',
+            getURL: 'nested.nonImgixUrl',
+          },
+        ],
+      },
+    });
+
+    const ImgixImageTestType = result.getType('ImgixImageTest');
+    const resolver = ImgixImageTestType.config.fields.imgixImage.resolve;
+    const node = {
+      nested: { nonImgixUrl: 'https://test.imgix.net/image.jpg' },
+    };
+    const resolved = resolver(node, {});
+
+    expect(resolved.rawURL).toEqual(node.nested.nonImgixUrl);
+  });
+  it('should accept string paths for getURL', async () => {
+    const result = await getTypeStoreFromSchemaCustomization({
+      appConfig: {
+        fields: [
+          {
+            nodeType: 'ImgixImageTest',
+            fieldName: 'imgixImage',
+            getURLs: ['nested.nonImgixUrl', 'nested.nonImgixUrl2'],
+          },
+        ],
+      },
+    });
+
+    const ImgixImageTestType = result.getType('ImgixImageTest');
+    const resolver = ImgixImageTestType.config.fields.imgixImage.resolve;
+    const node = {
+      nested: {
+        nonImgixUrl: 'https://test.imgix.net/image.jpg',
+        nonImgixUrl2: 'https://test.imgix.net/image.jpg',
+      },
+    };
+    const resolved = resolver(node, {});
+
+    expect(resolved.rawURL).toEqual([
+      node.nested.nonImgixUrl,
+      node.nested.nonImgixUrl2,
+    ]);
   });
 });
 

--- a/test/unit/source-url/source-url.test.ts
+++ b/test/unit/source-url/source-url.test.ts
@@ -507,14 +507,14 @@ describe('createResolvers', () => {
       expect(src.searchParams.get('h')).not.toBe(imgixParams.h.toString());
     });
   });
-  it('should accept string path for getURL', async () => {
+  it('should accept string path for rawURLKey', async () => {
     const result = await getTypeStoreFromSchemaCustomization({
       appConfig: {
         fields: [
           {
             nodeType: 'ImgixImageTest',
             fieldName: 'imgixImage',
-            getURL: 'nested.nonImgixUrl',
+            rawURLKey: 'nested.nonImgixUrl',
           },
         ],
       },
@@ -529,14 +529,14 @@ describe('createResolvers', () => {
 
     expect(resolved.rawURL).toEqual(node.nested.nonImgixUrl);
   });
-  it('should accept string paths for getURL', async () => {
+  it('should accept string paths for rawURLKey', async () => {
     const result = await getTypeStoreFromSchemaCustomization({
       appConfig: {
         fields: [
           {
             nodeType: 'ImgixImageTest',
             fieldName: 'imgixImage',
-            getURLs: ['nested.nonImgixUrl', 'nested.nonImgixUrl2'],
+            rawURLKeys: ['nested.nonImgixUrl', 'nested.nonImgixUrl2'],
           },
         ],
       },
@@ -565,7 +565,7 @@ describe('createResolvers', () => {
           {
             nodeType: 'ImgixImageTest',
             fieldName: 'imgixImage',
-            getURL: 'nested.nonImgixUrl',
+            rawURLKey: 'nested.nonImgixUrl',
             URLPrefix: 'https:'
           },
         ],
@@ -581,14 +581,14 @@ describe('createResolvers', () => {
 
     expect(resolved.rawURL).toEqual('https:'+ node.nested.nonImgixUrl);
   })
-  it('should accept string paths for getURL', async () => {
+  it('should accept string paths for rawURLKey', async () => {
     const result = await getTypeStoreFromSchemaCustomization({
       appConfig: {
         fields: [
           {
             nodeType: 'ImgixImageTest',
             fieldName: 'imgixImage',
-            getURLs: ['nested.nonImgixUrl', 'nested.nonImgixUrl2'],
+            rawURLKeys: ['nested.nonImgixUrl', 'nested.nonImgixUrl2'],
             URLPrefix: 'https:'
           },
         ],

--- a/test/unit/source-url/source-url.test.ts
+++ b/test/unit/source-url/source-url.test.ts
@@ -557,6 +557,60 @@ describe('createResolvers', () => {
       node.nested.nonImgixUrl2,
     ]);
   });
+
+  it('should add URLPrefix to single URL retrieved from node', async () => {
+    const result = await getTypeStoreFromSchemaCustomization({
+      appConfig: {
+        fields: [
+          {
+            nodeType: 'ImgixImageTest',
+            fieldName: 'imgixImage',
+            getURL: 'nested.nonImgixUrl',
+            URLPrefix: 'https:'
+          },
+        ],
+      },
+    });
+
+    const ImgixImageTestType = result.getType('ImgixImageTest');
+    const resolver = ImgixImageTestType.config.fields.imgixImage.resolve;
+    const node = {
+      nested: { nonImgixUrl: '//test.imgix.net/image.jpg' },
+    };
+    const resolved = resolver(node, {});
+
+    expect(resolved.rawURL).toEqual('https:'+ node.nested.nonImgixUrl);
+  })
+  it('should accept string paths for getURL', async () => {
+    const result = await getTypeStoreFromSchemaCustomization({
+      appConfig: {
+        fields: [
+          {
+            nodeType: 'ImgixImageTest',
+            fieldName: 'imgixImage',
+            getURLs: ['nested.nonImgixUrl', 'nested.nonImgixUrl2'],
+            URLPrefix: 'https:'
+          },
+        ],
+      },
+    });
+
+    const ImgixImageTestType = result.getType('ImgixImageTest');
+    const resolver = ImgixImageTestType.config.fields.imgixImage.resolve;
+    const node = {
+      nested: {
+        nonImgixUrl: '//test.imgix.net/image.jpg',
+        nonImgixUrl2: '//test.imgix.net/image.jpg',
+      },
+    };
+    const resolved = resolver(node, {});
+
+    expect(resolved.rawURL).toEqual([
+      'https:' + node.nested.nonImgixUrl,
+      'https:' + node.nested.nonImgixUrl2,
+    ]);
+  });
+
 });
 
 const mockGatsbyCache = {

--- a/test/unit/source-url/source-url.test.ts
+++ b/test/unit/source-url/source-url.test.ts
@@ -7,7 +7,7 @@ import { FixedObject, FluidObject } from 'gatsby-image';
 import {
   buildEnumType,
   buildInputObjectType,
-  buildObjectType
+  buildObjectType,
 } from 'gatsby/dist/schema/types/type-builders';
 import isBase64 from 'is-base64';
 import * as R from 'ramda';
@@ -566,7 +566,7 @@ describe('createResolvers', () => {
             nodeType: 'ImgixImageTest',
             fieldName: 'imgixImage',
             rawURLKey: 'nested.nonImgixUrl',
-            URLPrefix: 'https:'
+            URLPrefix: 'https:',
           },
         ],
       },
@@ -579,8 +579,8 @@ describe('createResolvers', () => {
     };
     const resolved = resolver(node, {});
 
-    expect(resolved.rawURL).toEqual('https:'+ node.nested.nonImgixUrl);
-  })
+    expect(resolved.rawURL).toEqual('https:' + node.nested.nonImgixUrl);
+  });
   it('should accept string paths for rawURLKey', async () => {
     const result = await getTypeStoreFromSchemaCustomization({
       appConfig: {
@@ -589,7 +589,7 @@ describe('createResolvers', () => {
             nodeType: 'ImgixImageTest',
             fieldName: 'imgixImage',
             rawURLKeys: ['nested.nonImgixUrl', 'nested.nonImgixUrl2'],
-            URLPrefix: 'https:'
+            URLPrefix: 'https:',
           },
         ],
       },
@@ -610,7 +610,6 @@ describe('createResolvers', () => {
       'https:' + node.nested.nonImgixUrl2,
     ]);
   });
-
 });
 
 const mockGatsbyCache = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2882,6 +2882,18 @@
     "@types/node" "*"
     rxjs "^6.5.1"
 
+"@types/lodash.get@^4.4.6":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.get/-/lodash.get-4.4.6.tgz#0c7ac56243dae0f9f09ab6f75b29471e2e777240"
+  integrity sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.178"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
+  integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
+
 "@types/lodash@^4.14.92":
   version "4.14.178"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
@@ -10206,7 +10218,7 @@ lodash.foreach@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
   integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
 
-lodash.get@^4:
+lodash.get@^4, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=


### PR DESCRIPTION
This will release the current changes below: 

### [1.7.6-rc.1](v1.7.5...v1.7.6-rc.1) (2022-02-14)

### ⚠ BREAKING CHANGES

* change getURL config from function to string

### Features

* change getURL config from function to string ([0844948](0844948))

