### PR TITLE
chore(fp-ts): refactor createSchemaCustomization api

### DIFF
--- a/src/modules/gatsby-plugin/gatsby-node.ts
+++ b/src/modules/gatsby-plugin/gatsby-node.ts
@@ -1,7 +1,11 @@
-import { Do } from 'fp-ts-contrib/lib/Do';
 import * as E from 'fp-ts/Either';
 import { pipe } from 'fp-ts/pipeable';
-import { ICreateSchemaCustomizationHook, PatchedPluginOptions } from 'gatsby';
+import {
+  CreateSchemaCustomizationArgs,
+  GatsbyGraphQLObjectType,
+  ICreateSchemaCustomizationHook,
+  PatchedPluginOptions,
+} from 'gatsby';
 import { GraphQLNonNull, GraphQLString } from 'gatsby/graphql';
 import { PathReporter } from 'io-ts/PathReporter';
 import get from 'lodash.get';
@@ -53,6 +57,14 @@ const getFieldValue = ({
     const _neverReturn: never = fieldOptions; // Fixes typescript error 'not all code paths return a value'
     return _neverReturn;
   })();
+
+/**
+ * "Decode" the options that the user set in gatsby-config.js, to verify that
+ * they match our expected options schema. If they don't, the Either will
+ * contain an error.
+ * @param options The options object from gatsby-config.js
+ * @returns Either containing the options object if they are valid, or an error
+ */
 const decodeOptionsE = (options: PatchedPluginOptions<IImgixGatsbyOptions>) =>
   pipe(
     options,
@@ -109,174 +121,206 @@ const setupImgixClient = ({
         : undefined,
   });
 
+/**
+ * createSchemaCustomaztion is a Gatsby core API hook which can be used to
+ * update the GraphQL schema.
+ * Here, we use it to add our imgix GraphQL types, as well as add fields to the
+ * corresponding types, which are the types that the user has specified to
+ * transform, as well as the the root Query type (this adds the imgixImage type
+ * to the root query)
+ */
 export const createSchemaCustomization: ICreateSchemaCustomizationHook<IImgixGatsbyOptions> = async (
   gatsbyContext,
   _options,
-): Promise<any> =>
-  pipe(
-    Do(E.either)
-      .bind('options', decodeOptionsE(_options))
+): Promise<void> => {
+  const validatedOptions = decodeOptionsE(_options);
+  if (E.isLeft(validatedOptions)) {
+    const errorString = `[@imgix/gatsby] Fatal error during setup, plugin options are not valid: ${String(
+      validatedOptions.left,
+    )}`;
+    gatsbyContext.reporter.panic(errorString);
+    throw new Error(errorString);
+  }
 
-      .let('packageVersion', VERSION)
-      .letL('imgixClient', ({ options, packageVersion }) =>
-        setupImgixClient({ options, packageVersion }),
-      )
-      .letL(
-        'typesAndFields',
-        ({ imgixClient, options: { defaultImgixParams } }) =>
-          buildImgixGatsbyTypes<{ rawURL: string }>({
-            cache: gatsbyContext.cache,
-            imgixClient,
-            resolveUrl: prop('rawURL'),
-            defaultParams: defaultImgixParams,
-          }),
-      )
-      .letL('imgixImageType', ({ typesAndFields }) =>
-        gatsbyContext.schema.buildObjectType({
-          name: 'ImgixImage',
-          fields: {
-            url: typesAndFields.fields.url,
-            fluid: typesAndFields.fields.fluid,
-            fixed: typesAndFields.fields.fixed,
-            gatsbyImageData: typesAndFields.fields.gatsbyImageData,
-          },
-        }),
-      )
-      .letL(
-        'fieldTypes',
-        ({ imgixImageType, options: { domain, fields = [] } }) =>
-          fields.map((fieldOptions) =>
-            gatsbyContext.schema.buildObjectType({
-              name: `${fieldOptions.nodeType}`,
-              // We have to declare that we're extending the Node interface here
-              // This does the same as 'implements Node' does for SDL-defined types.
-              // See here for more info:
-              // https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#:~:text=when%20defining%20top-level%20types%2C%20don%E2%80%99t%20forget%20to%20pass%20interfaces%3A%20%5B'node'%5D%2C%20which%20does%20the%20same%20for%20type%20builders%20as%20adding%20implements%20node%20does%20for%20sdl-defined%20types.%20
-              interfaces: ['Node'],
-              fields: {
-                [fieldOptions.fieldName]: {
-                  type:
-                    'rawURLKeys' in fieldOptions
-                      ? `[${imgixImageType.config.name}]`
-                      : imgixImageType.config.name,
-                  resolve: (node: unknown): { rawURL: string | string[] } => {
-                    const rawURLE = getFieldValue({
-                      fieldOptions,
-                      node,
-                    });
+  // This creates the "imgix client" (it is actually a modified version of the
+  // core imgix client), which will be passed around to be used in the
+  // application
+  const imgixClient = setupImgixClient({
+    options: validatedOptions.right,
+    packageVersion: VERSION,
+  });
 
-                    return {
-                      rawURL: E.getOrElseW(() => {
-                        const urlPathsFound =
-                          typeof node === 'object' && node != null
-                            ? findPossibleURLsInNode(node)
-                            : [];
+  // Create the imgix GraphQL types, which will be added to the schema later
+  const typesAndFields = buildImgixGatsbyTypes<{ rawURL: string }>({
+    cache: gatsbyContext.cache,
+    imgixClient,
+    resolveUrl: prop('rawURL'),
+    defaultParams: validatedOptions.right.defaultImgixParams,
+  });
 
-                        const potentialImagesString = (() => {
-                          if (urlPathsFound.length === 0) {
-                            return '';
-                          }
+  // Create the root "imgixImage" type which will exist at the root of the
+  // GraphQL Query type, and also on every type that the user has specified to
+  // modify
+  const imgixImageType = gatsbyContext.schema.buildObjectType({
+    name: 'ImgixImage',
+    fields: {
+      url: typesAndFields.fields.url,
+      fluid: typesAndFields.fields.fluid,
+      fixed: typesAndFields.fields.fixed,
+      gatsbyImageData: typesAndFields.fields.gatsbyImageData,
+    },
+  });
 
-                          let output = '';
-                          output +=
-                            'Potential images were found at these paths:\n';
-                          urlPathsFound.map(({ path, value }) => {
-                            output += ` - ${path}\n`;
+  const optionsFields = validatedOptions.right.fields ?? [];
 
-                            if (value.startsWith('http')) {
-                              output +=
-                                '   Set following configuration options:\n';
-                              output += `     rawURLKey: '${path}'\n`;
-                              output += `     URLPrefix: 'https:'\n`;
-                            } else {
-                              output +=
-                                '   Set following configuration option:\n';
-                              output += `     rawURLKey: '${path}'\n`;
-                            }
-                          });
-                          return output;
-                        })();
-
-                        return gatsbyContext.reporter.panic(
-                          `Error when resolving URL value for node type ${fieldOptions.nodeType}. This probably means that the rawURLKey function in gatsby-config.js is incorrectly set. Please read this project's README for detailed instructions on how to set this correctly.
-                          
-${potentialImagesString}`,
-                        );
-                      })(rawURLE),
-                    };
-                  },
-                },
-              },
-            }),
-          ),
-      )
-      .letL(`rootType`, ({ imgixImageType }) =>
-        gatsbyContext.schema.buildObjectType({
-          name: 'Query',
-          fields: {
-            imgixImage: {
-              type: imgixImageType.config.name,
-              resolve(
-                _: any,
-                args: Record<string, unknown>,
-              ): IRootSource | null {
-                if (args?.url == null || typeof args?.url !== 'string') {
-                  return null;
-                }
-                return { rawURL: args?.url };
-              },
-              args: {
-                url: {
-                  type: GraphQLNonNull(GraphQLString),
-                  description:
-                    'The path of the image to render. If using a Web Proxy Source, this must be a fully-qualified URL.',
-                },
-              },
-            },
-          },
-        }),
-      )
-      // prettier-ignore
-      .doL(
-        ({
-          typesAndFields,
-          imgixImageType,
-          rootType,
-          fieldTypes,
-          options: {},
-        }) =>
-          E.tryCatch(
-            () => {
-              const { createTypes } = gatsbyContext.actions;
-              createTypes(
-                typesAndFields.types.map(gatsbyContext.schema.buildObjectType),
-              );
-              createTypes(
-                typesAndFields.enumTypes.map(
-                  gatsbyContext.schema.buildEnumType,
-                ),
-              );
-              createTypes(
-                typesAndFields.inputTypes.map(
-                  gatsbyContext.schema.buildInputObjectType,
-                ),
-              );
-              createTypes(fieldTypes);
-              createTypes(imgixImageType);
-              createTypes(rootType);
-            },
-            (e) => (e instanceof Error ? e : new Error('unknown error')),
-          ),
-      )
-      .return(() => undefined),
-    E.getOrElseW((err) => {
-      gatsbyContext.reporter.panic(
-        `[@imgix/gatsby] Fatal error during setup: ${String(err)}`,
-      );
-      throw err;
-    }),
+  const fieldTypes = createFieldTypes(
+    optionsFields,
+    gatsbyContext,
+    imgixImageType,
   );
+  const rootType = createRootObjectType(gatsbyContext, imgixImageType);
+
+  // Now, we actually add the types and fields to the schema
+  try {
+    const { createTypes } = gatsbyContext.actions;
+    createTypes(typesAndFields.types.map(gatsbyContext.schema.buildObjectType));
+    createTypes(
+      typesAndFields.enumTypes.map(gatsbyContext.schema.buildEnumType),
+    );
+    createTypes(
+      typesAndFields.inputTypes.map(gatsbyContext.schema.buildInputObjectType),
+    );
+    createTypes(fieldTypes);
+    createTypes(imgixImageType);
+    createTypes(rootType);
+  } catch (error) {
+    const errorString =
+      '[@imgix/gatsby] Error during setup when creating GraphQL types: ' +
+      String(error);
+    gatsbyContext.reporter.panic(errorString);
+    throw new Error(errorString);
+  }
+};
 
 type IRootSource = {
   rawURL: string;
 };
+
+/**
+ * This "creates" a 'Query' type, with our imgixImage type as a field. Gatsby
+ * will then later merge this with its own Query type, effectively adding our
+ * imgixImage field to the root of the GraphQL schema.
+ * @param gatsbyContext Gatsby context object passed into Gatsby hooks
+ * @param imgixImageType The imgix image GraphQL type
+ * @returns A GraphQL object type representing the GraphQL Query type.
+ */
+function createRootObjectType(
+  gatsbyContext: CreateSchemaCustomizationArgs,
+  imgixImageType: GatsbyGraphQLObjectType,
+) {
+  return gatsbyContext.schema.buildObjectType({
+    // 'Query' here refers to the root GraphQL Query type
+    name: 'Query',
+    fields: {
+      imgixImage: {
+        type: imgixImageType.config.name,
+        resolve(_: any, args: Record<string, unknown>): IRootSource | null {
+          // If url is not defined, return null. In reality this shouldn't
+          // happen due to the GraphQL type definition (below) ensuring that
+          // this is not null.
+          if (args?.url == null || typeof args?.url !== 'string') {
+            return null;
+          }
+
+          // This "raw url" is transformed later in the resolvers for the fields
+          // that are children of this type
+          return { rawURL: args?.url };
+        },
+        args: {
+          url: {
+            type: GraphQLNonNull(GraphQLString),
+            description:
+              'The path of the image to render. If using a Web Proxy Source, this must be a fully-qualified URL.',
+          },
+        },
+      },
+    },
+  });
+}
+
+/**
+ * This function "creates" types for the types that the user has specified that
+ * we should modify. Gatsby will later merge these with the existing types,
+ * adding our imgixImage field to the types that the user has specified.
+ * @param optionsFields The fields that the user has specified to modify
+ * @param gatsbyContext Gatsby context object passed into Gatsby hooks
+ * @param imgixImageType The imgix image GraphQL type
+ * @returns An array of GraphQL types, corresponding to the types that the user has specified to modify
+ */
+function createFieldTypes(
+  optionsFields: Exclude<IImgixGatsbyOptions['fields'], undefined>,
+  gatsbyContext: CreateSchemaCustomizationArgs,
+  imgixImageType: GatsbyGraphQLObjectType,
+) {
+  return optionsFields.map((fieldOptions) =>
+    gatsbyContext.schema.buildObjectType({
+      name: `${fieldOptions.nodeType}`,
+      // We have to declare that we're extending the Node interface here
+      // This does the same as 'implements Node' does for SDL-defined types.
+      // See here for more info:
+      // https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#:~:text=when%20defining%20top-level%20types%2C%20don%E2%80%99t%20forget%20to%20pass%20interfaces%3A%20%5B'node'%5D%2C%20which%20does%20the%20same%20for%20type%20builders%20as%20adding%20implements%20node%20does%20for%20sdl-defined%20types.%20
+      interfaces: ['Node'],
+      fields: {
+        [fieldOptions.fieldName]: {
+          type:
+            'rawURLKeys' in fieldOptions
+              ? `[${imgixImageType.config.name}]`
+              : imgixImageType.config.name,
+          resolve: (node: unknown): { rawURL: string | string[] } => {
+            const rawURLE = getFieldValue({
+              fieldOptions,
+              node,
+            });
+
+            return {
+              rawURL: E.getOrElseW(() => {
+                const urlPathsFound =
+                  typeof node === 'object' && node != null
+                    ? findPossibleURLsInNode(node)
+                    : [];
+
+                const potentialImagesString = (() => {
+                  if (urlPathsFound.length === 0) {
+                    return '';
+                  }
+
+                  let output = '';
+                  output += 'Potential images were found at these paths:\n';
+                  urlPathsFound.map(({ path, value }) => {
+                    output += ` - ${path}\n`;
+
+                    if (value.startsWith('http')) {
+                      output += '   Set following configuration options:\n';
+                      output += `     rawURLKey: '${path}'\n`;
+                      output += `     URLPrefix: 'https:'\n`;
+                    } else {
+                      output += '   Set following configuration option:\n';
+                      output += `     rawURLKey: '${path}'\n`;
+                    }
+                  });
+                  return output;
+                })();
+
+                return gatsbyContext.reporter.panic(
+                  `Error when resolving URL value for node type ${fieldOptions.nodeType}. This probably means that the rawURLKey function in gatsby-config.js is incorrectly set. Please read this project's README for detailed instructions on how to set this correctly.
+                      
+${potentialImagesString}`,
+                );
+              })(rawURLE),
+            };
+          },
+        },
+      },
+    }),
+  );
+}


### PR DESCRIPTION
This PR refactors the `createSchemaCustomization` top level Gatsby hook to not use fp-ts. @sherwinski @luqven please let me know if there's anything I can improve in my style of my refactoring, as a lot of the future refactoring will be in the same style