### PR TITLE
chore: refactor return type of fetchImgixMetadata

### DIFF
--- a/src/api/fetchImgixMetadata.ts
+++ b/src/api/fetchImgixMetadata.ts
@@ -1,4 +1,3 @@
-import * as TE from 'fp-ts/TaskEither';
 import { GatsbyCache } from 'gatsby';
 import fetch from 'node-fetch';
 import { withCache } from '../common/cache';
@@ -52,12 +51,8 @@ const fetchImgixMetadataAPI = async (
 export const fetchImgixMetadata = (
   cache: GatsbyCache,
   client: IImgixURLBuilder,
-) => (url: string): TE.TaskEither<Error, IImgixMetadata> => {
-  return TE.tryCatch(
-    () =>
-      withCache(`gatsby-plugin-imgix-metadata-${url}`, cache, () =>
-        fetchImgixMetadataAPI(url, client),
-      ),
-    () => new Error(`Couldn't fetch imgix metadata for ${url}`),
+) => (url: string): Promise<IImgixMetadata> => {
+  return withCache(`gatsby-plugin-imgix-metadata-${url}`, cache, () =>
+    fetchImgixMetadataAPI(url, client),
   );
 };

--- a/src/modules/gatsby-plugin/resolveDimensions.ts
+++ b/src/modules/gatsby-plugin/resolveDimensions.ts
@@ -41,16 +41,18 @@ export const resolveDimensions = <TSource>({
   return pipe(
     WidthHeightTE,
     TE.map(trace('manual width and height', log)),
-    TE.orElse(() =>
-      pipe(
-        url,
-        fetchImgixMetadata(cache, client),
+    TE.orElse(() => {
+      return pipe(
+        TE.tryCatch(
+          () => fetchImgixMetadata(cache, client)(url),
+          () => new Error('Something went wrong fetching the image metadata'),
+        ),
         TE.map(trace('fetchImgixMetadata result', log)),
         TE.map(({ PixelWidth, PixelHeight }) => ({
           width: PixelWidth,
           height: PixelHeight,
         })),
-      ),
-    ),
+      );
+    }),
   );
 };


### PR DESCRIPTION
This is part of the Gatsby fp-ts refactor.

