### PR TITLE
chore: use pluginOptionsSchema for options type checking

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -17,6 +17,7 @@ export const onPreInit: GatsbyNode['onPreInit'] = ({ reporter }) => {
 };
 
 export { createSchemaCustomization } from './modules/gatsby-plugin/gatsby-node';
+export { pluginOptionsSchema } from './modules/gatsby-plugin/pluginOptionsSchema';
 
 export const onPreExtractQueries: GatsbyNode['onPreExtractQueries'] = ({
   store,

--- a/src/modules/gatsby-plugin/gatsby-node.ts
+++ b/src/modules/gatsby-plugin/gatsby-node.ts
@@ -5,10 +5,8 @@ import {
   PatchedPluginOptions,
 } from 'gatsby';
 import { GraphQLNonNull, GraphQLString } from 'gatsby/graphql';
-import Joi from 'joi';
 import get from 'lodash.get';
 import { prop } from 'ramda';
-import { ImgixGatsbyOptionsJOI } from '.';
 import { IImgixGatsbyOptions, ImgixSourceType } from '../..';
 import { VERSION } from '../../common/constants';
 import {
@@ -75,42 +73,27 @@ const getFieldValue = ({
  * @returns The options object if it is valid, or throws an error
  */
 const decodeOptions = (options: PatchedPluginOptions<IImgixGatsbyOptions>) => {
-  const validatedOptions = ImgixGatsbyOptionsJOI.validate(options);
-  if (Joi.isError(validatedOptions.error) || !validatedOptions.value) {
-    throw new Error(
-      `The plugin config is not in the correct format. Errors: ${
-        Joi.isError(validatedOptions.error)
-          ? validatedOptions.error.annotate()
-          : ''
-      }`,
-    );
-  }
-
-  const decodedOptions = validatedOptions.value;
-
   if (
-    decodedOptions.sourceType === 'webProxy' &&
-    (decodedOptions.secureURLToken == null ||
-      decodedOptions.secureURLToken.trim() === '')
+    options.sourceType === 'webProxy' &&
+    (options.secureURLToken == null || options.secureURLToken.trim() === '')
   ) {
     throw new Error(
       `The plugin option 'secureURLToken' is required when sourceType is 'webProxy'.`,
     );
   }
-  if (decodedOptions.fields != null && !Array.isArray(decodedOptions.fields)) {
+  if (options.fields != null && !Array.isArray(options.fields)) {
     throw new Error('Fields must be an array of field options');
   }
   if (
-    decodedOptions.sourceType === ImgixSourceType.WebProxy &&
-    (decodedOptions.secureURLToken == null ||
-      decodedOptions.secureURLToken.trim() === '')
+    options.sourceType === ImgixSourceType.WebProxy &&
+    (options.secureURLToken == null || options.secureURLToken.trim() === '')
   ) {
     throw new Error(
       'A secure URL token must be provided if sourceType is webProxy',
     );
   }
 
-  return decodedOptions;
+  return options;
 };
 
 const setupImgixClient = ({

--- a/src/modules/gatsby-plugin/pluginOptionsSchema.ts
+++ b/src/modules/gatsby-plugin/pluginOptionsSchema.ts
@@ -1,0 +1,105 @@
+import { GatsbyNode } from 'gatsby';
+import imgixUrlParameters from 'imgix-url-params/dist/parameters.json';
+import { mapObjIndexed } from 'ramda';
+import { IImgixGatsbyOptions } from '../../publicTypes';
+
+/**
+ * Run during the bootstrap phase. Plugins can use this to define a schema for
+ * their options using Joi to validate the options users pass to the plugin.
+ *
+ * @see https://www.gatsbyjs.com/docs/reference/config-files/gatsby-node/#pluginOptionsSchema
+ */
+export const pluginOptionsSchema: NonNullable<
+  GatsbyNode['pluginOptionsSchema']
+> = function (args) {
+  const { Joi } = args;
+
+  const ImgixSourceTypeJOI = Joi.string().valid(
+    's3',
+    'gcs',
+    'azure',
+    'webFolder',
+    'webProxy',
+  );
+
+  const ImgixParamValueJOI = Joi.alternatives()
+    .try(
+      Joi.string(),
+      Joi.number(),
+      Joi.boolean(),
+      Joi.array().items(Joi.string()),
+      Joi.array().items(Joi.number()),
+      Joi.array().items(Joi.boolean()),
+    )
+    .optional()
+    .allow(null);
+
+  const mapToImgixParamJOIValue = <TKey extends string>(
+    obj: Record<TKey, unknown>,
+  ): Record<TKey, typeof ImgixParamValueJOI> =>
+    mapObjIndexed(() => ImgixParamValueJOI, obj);
+
+  const ImgixParamsJOI = Joi.object().keys({
+    ...mapToImgixParamJOIValue(imgixUrlParameters.aliases),
+    ...mapToImgixParamJOIValue(imgixUrlParameters.parameters),
+  });
+
+  const ImgixGatsbyFieldsJOI = Joi.array().items(
+    Joi.object()
+      .keys({
+        nodeType: Joi.string()
+          .required()
+          .description('The GraphQL node type to modify.'),
+        fieldName: Joi.string()
+          .required()
+          .description(
+            'The name for the imgix field that will be added to the corresponding node type',
+          ),
+        URLPrefix: Joi.string()
+          .optional()
+          .description(
+            'The prefix to add to the image URL resolved from the node data',
+          ),
+        rawURLKeys: Joi.array()
+          .items(Joi.string())
+          .description('Where to get the image URL from the node data'),
+        rawURLKey: Joi.string().description(
+          'The path to get the image URL from the node data',
+        ),
+      })
+      .xor('rawURLKeys', 'rawURLKey'),
+  );
+
+  const schema = Joi.object<IImgixGatsbyOptions & { plugins: any }>().keys({
+    domain: Joi.string()
+      .required()
+      .description(
+        "This is the domain of your imgix source, which can be created at https://dashboard.imgix.com/. The source specified must be a 'Web Proxy' source type.",
+      ),
+    secureURLToken: Joi.string()
+      .optional()
+      .description(
+        "This is the source's secure token. Can be found under the 'Security' heading in your source's configuration page, and revealed by tapping 'Show Token'.",
+      ),
+    defaultImgixParams: ImgixParamsJOI.optional().description(
+      'These are the default imgix parameters to apply to every image.',
+    ),
+    disableIxlibParam: Joi.boolean()
+      .optional()
+      .description(
+        'Set to `true` to remove the `ixlib` param from every request.',
+      ),
+    sourceType: ImgixSourceTypeJOI.optional().description(
+      'This should specify the type of imgix source that is used for this plugin',
+    ),
+    fields: ImgixGatsbyFieldsJOI.optional().description(
+      'If set, the plugin will transform these node types to add imgixImage fields to the corresponding types.',
+    ),
+    // This seems to be added by Gatsby automatically, although it has no
+    // relevance to our plugin. We have to include this otherwise validation
+    // fails
+    plugins: Joi.any(),
+  });
+
+  return schema;
+};

--- a/src/publicTypes.ts
+++ b/src/publicTypes.ts
@@ -1,6 +1,4 @@
 import imgixUrlParameters from 'imgix-url-params/dist/parameters.json';
-import Joi from 'joi';
-import { mapObjIndexed } from 'ramda';
 
 export enum ImgixSourceType {
   AmazonS3 = 's3',
@@ -10,29 +8,10 @@ export enum ImgixSourceType {
   WebProxy = 'webProxy',
 }
 
-const ImgixSourceTypeJOI = Joi.string().valid(
-  's3',
-  'gcs',
-  'azure',
-  'webFolder',
-  'webProxy',
-);
-
 type IImgixParamsKey =
   | keyof ImgixUrlParametersSpec['parameters']
   | keyof ImgixUrlParametersSpec['aliases'];
 
-const ImgixParamValueJOI = Joi.alternatives()
-  .try(
-    Joi.string(),
-    Joi.number(),
-    Joi.boolean(),
-    Joi.array().items(Joi.string()),
-    Joi.array().items(Joi.number()),
-    Joi.array().items(Joi.boolean()),
-  )
-  .optional()
-  .allow(null);
 type ImgixParamValue =
   | string
   | number
@@ -43,16 +22,6 @@ type ImgixParamValue =
   | undefined
   | null;
 
-const mapToImgixParamJOIValue = <TKey extends string>(
-  obj: Record<TKey, unknown>,
-): Record<TKey, typeof ImgixParamValueJOI> =>
-  mapObjIndexed(() => ImgixParamValueJOI, obj);
-
-const ImgixParamsJOI = Joi.object().keys({
-  ...mapToImgixParamJOIValue(imgixUrlParameters.aliases),
-  ...mapToImgixParamJOIValue(imgixUrlParameters.parameters),
-});
-
 export type IImgixParams = Partial<Record<IImgixParamsKey, ImgixParamValue>>;
 
 export interface IBaseFieldOptions {
@@ -61,39 +30,9 @@ export interface IBaseFieldOptions {
   URLPrefix?: string;
 }
 
-export const ImgixGatsbyFieldsJOI = Joi.array().items(
-  Joi.object()
-    .keys({
-      nodeType: Joi.string().required(),
-      fieldName: Joi.string().required(),
-      URLPrefix: Joi.string().optional(),
-      rawURLKeys: Joi.array().items(Joi.string()),
-      rawURLKey: Joi.string(),
-      // This seems to be added by Gatsby automatically, although it has no
-      // relevance to our plugin. We have to include this otherwise validation
-      // fails
-      plugins: Joi.any(),
-    })
-    .xor('rawURLKeys', 'rawURLKey'),
-);
-
 export type IFieldsOption = (IBaseFieldOptions &
   ({ rawURLKeys: string[] } | { rawURLKey: string }))[];
 
-export const ImgixGatsbyOptionsJOI = Joi.object<
-  IImgixGatsbyOptions & { plugins: any }
->().keys({
-  domain: Joi.string().required(),
-  defaultImgixParams: ImgixParamsJOI.optional(),
-  disableIxlibParam: Joi.boolean().optional(),
-  secureURLToken: Joi.string().optional(),
-  sourceType: ImgixSourceTypeJOI.optional(),
-  fields: ImgixGatsbyFieldsJOI.optional(),
-  // This seems to be added by Gatsby automatically, although it has no
-  // relevance to our plugin. We have to include this otherwise validation
-  // fails
-  plugins: Joi.any(),
-});
 export type IImgixGatsbyOptions = {
   domain: string;
   defaultImgixParams?: IImgixParams;


### PR DESCRIPTION
From recommendation from Angelo, this should be used instead of doing our own type checking for the plugin options
