### PR TITLE
chore: add issues gh action

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,18 @@
+name: Add issues to project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project
+        with:
+          project-url: https://github.com/orgs/imgix/projects/4
+          github-token: ${{ secrets.GH_TOKEN }}
+          labeled: bug, needs-triage
+          label-operator: OR


### PR DESCRIPTION
This commit adds a GH action to automatically add opened issues with the bug or needs-triage tags to the SDK issues project board.