### PR TITLE
ci(deploy): add prepare step

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "load-env": "source .env",
     "nodemon:dev": "nodemon --delay 1 -w dist -x \"yarn run sync:e2e && yarn run dev:start\"",
     "nodemon:e2e": "nodemon --delay 1 -w dist -x \"yarn run test:e2e:ci\"",
+    "prepare": "yarn build",
     "prepublishOnly": "yarn build",
     "sync:e2e:watch": "nodemon -w dist -x \"msync s && rm -rf test/dev-and-e2e/node_modules/@imgix/gatsby/test/\"",
     "sync:e2e": "msync s && rm -rf test/dev-and-e2e/node_modules/@imgix/gatsby/test/",


### PR DESCRIPTION
Adds additional script to ensure properly updated `dist` prior to release.

# Before

Library is not guaranteed to execute a `build` step to properly update `dist` directory prior to deployment; as a result, some libraries include the prior release in their `dist` folder.

# After

We include both a `prepare` and a `prepublishOnly` step to ensure that the library executes a build prior to deploying a release.
