### PR TITLE
fix: set domain as optional

### DIFF
--- a/src/modules/gatsby-plugin/pluginOptionsSchema.ts
+++ b/src/modules/gatsby-plugin/pluginOptionsSchema.ts
@@ -72,7 +72,7 @@ export const pluginOptionsSchema: NonNullable<
 
   const schema = Joi.object<IImgixGatsbyOptions & { plugins: any }>().keys({
     domain: Joi.string()
-      .required()
+      .optional()
       .description(
         "This is the domain of your imgix source, which can be created at https://dashboard.imgix.com/. The source specified must be a 'Web Proxy' source type.",
       ),

--- a/test/unit/pluginHelpers.test.ts
+++ b/test/unit/pluginHelpers.test.ts
@@ -1,18 +1,21 @@
 import * as fetchImgixMetadataModule from '../../src/api/fetchImgixMetadata';
+import { createImgixUrlSchemaFieldConfig } from '../../src/modules/gatsby-plugin/createImgixUrlFieldConfig';
 import { createImgixGatsbyTypes } from '../../src/pluginHelpers';
 
-// test('should be able to call createImgixUrlFieldConfig with no domain and resolve a url', async () => {
-//   const config = createImgixUrlSchemaFieldConfig({
-//     resolveUrl: (node) => (node as any).url,
-//   });
+test('should be able to call createImgixUrlFieldConfig with no domain and resolve a url', async () => {
+  const config = createImgixUrlSchemaFieldConfig({
+    imgixClientOptions: { domain: '' },
+    resolveUrl: () => 'https://assets.imgix.net/amsterdam.jpg',
+    paramsInputType: '',
+  });
 
-//   const resolved = await (config as any).resolve(
-//     { url: 'https://assets.imgix.net/amsterdam.jpg' },
-//     {},
-//   );
+  const resolved = await (config as any).resolve(
+    { url: 'https://assets.imgix.net/amsterdam.jpg' },
+    {},
+  );
 
-//   expect(resolved).toMatch(/^https:\/\/assets.imgix.net\/amsterdam.jpg\?/);
-// });
+  expect(resolved).toMatch(/^https:\/\/assets.imgix.net\/amsterdam.jpg\?/);
+});
 // test('should be able to call createImgixUrlFieldConfig with a domain and resolve a url', async () => {
 //   const config = createImgixUrlSchemaFieldConfig({
 //     resolveUrl: (node) => (node as any).url,


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description

Fix regression where `domain` was set as required in the configuration options.

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->
## Before
The `domain` configuration field was set as `required`.
<!-- After this PR... -->
## After
`domain` can be set to an empty string, allowing absolute URLs to be used with the plugin.
<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->
