### PR TITLE
fix(deps): update gatsby-plugin-image range

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "gatsby": "^2 || ^3 || ^4 || ^5",
     "gatsby-image": "^2 || ^3",
-    "gatsby-plugin-image": "^1 || ^2"
+    "gatsby-plugin-image": "^1 || ^2 || ^3"
   },
   "resolutions": {
     "chalk": "^4",


### PR DESCRIPTION
## Description

This PR bumps `gatsby-plugin-image` version ranges to include v3. Fixes an installation issue with Gatsby v5, which requires version 3.