### PR TITLE
chore: merge next into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [2.1.2-rc.1](https://github.com/imgix/gatsby/compare/v2.1.1...v2.1.2-rc.1) (2023-02-14)
+
+
+### Bug Fixes
+
+* **deps:** update gatsby-plugin-image range ([fecccdf](https://github.com/imgix/gatsby/commit/fecccdf71f26298e809234d2cdc13f52a6bc54c9))
+
 ### [2.1.1](https://github.com/imgix/gatsby/compare/v2.1.0...v2.1.1) (2023-02-06)
 
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.1",
+  "version": "2.1.2-rc.1",
   "name": "@imgix/gatsby",
   "description": "The official imgix plugin to apply imgix transformations and optimisations to images in Gatsby at build-time or request-time",
   "author": "Frederick Fogerty <frederick@imgix.com>",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "gatsby": "^2 || ^3 || ^4 || ^5",
     "gatsby-image": "^2 || ^3",
-    "gatsby-plugin-image": "^1 || ^2"
+    "gatsby-plugin-image": "^1 || ^2 || ^3"
   },
   "resolutions": {
     "chalk": "^4",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,1 +1,1 @@
-export const VERSION = '2.1.1';
+export const VERSION = '2.1.2-rc.1';


### PR DESCRIPTION
## Description

Merge `next` into `main`

Closes: #266 

- [fix(deps): update gatsby-plugin-image range](https://github.com/imgix/gatsby/commit/fecccdf71f26298e809234d2cdc13f52a6bc54c9)
- [chore(release): 2.1.2-rc.1](https://github.com/imgix/gatsby/commit/d543df97923697cd135611cad9f2b170fa70e336)