### PR TITLE
fix(graphql-types): ensure short-description is defined 

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "common-tags": "^1.8.0",
     "debug": "^4.3.1",
     "graphql-compose": "^9.0.0",
-    "imgix-url-params": "^11.11.2",
+    "imgix-url-params": "^11.15.0",
     "joi": "^17.6.0",
     "jsuri": "^1.3.1",
     "lodash.get": "^4.4.2",

--- a/src/modules/gatsby-plugin/graphqlTypes.ts
+++ b/src/modules/gatsby-plugin/graphqlTypes.ts
@@ -38,6 +38,8 @@ export const ImgixParamsInputType = ({
         new Set(expects.map((expect) => expect.type)),
       );
 
+      // @ts-expect-error TODO: remove this after short_description is marked as required in imgix-url-params
+      const shortDescription = spec.short_description || spec.display_name;
       const type = expectsTypes.every((type) => type === 'integer')
         ? 'Int'
         : expectsTypes.every(
@@ -52,9 +54,9 @@ export const ImgixParamsInputType = ({
       fields[name] = {
         type,
         description:
-          spec.short_description +
+          shortDescription +
           // Ensure the description ends with a period.
-          (spec.short_description.slice(-1) === '.' ? '' : '.'),
+          (shortDescription.slice(-1) === '.' ? '' : '.'),
       };
 
       const field = fields[

--- a/yarn.lock
+++ b/yarn.lock
@@ -7815,10 +7815,10 @@ ignore@^5.1.8, ignore@^5.2.0:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
-imgix-url-params@^11.11.2:
-  version "11.12.0"
-  resolved "https://registry.npmjs.org/imgix-url-params/-/imgix-url-params-11.12.0.tgz"
-  integrity sha512-Q/P1vlxu3tKw2FatBTuVPuMvJaAYuso6yFO0UXX7QWWUsguhG2sSuBFnCpywefKPEM8Lw9dbhpSney374lD0Sg==
+imgix-url-params@^11.15.0:
+  version "11.15.0"
+  resolved "https://registry.yarnpkg.com/imgix-url-params/-/imgix-url-params-11.15.0.tgz#fa43b16a7e589bc20f4e646098246a70827de2cb"
+  integrity sha512-W8JprYztwdFTtNLTa/aj2PGh8CJNBaMKrTtgOYlo8OvJrRn3XELRTeZoLyob5C49qW9aFiIYIIqm8zWysRFu8g==
 
 immer@^9.0.7:
   version "9.0.15"


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

This PR ensures that `spec.short_description` is defined before it's accessed. There is the possibility a param does not include that property so we should not assume it is always defined.

This PR also bumps the `imgix-url-params` dependency version to the newest version.

<!-- Before this PR... -->

### Before
Buils would break because the `short_name` prop was not defined when accessed.

<!-- After this PR... -->

### After
Build succeeded, as we check that it's defined before accessing.

<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->

## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [x] Update or add any necessary API documentation (if applicable)
- [x] All existing unit tests are still passing (if applicable).

## Links

- Addresses https://github.com/imgix/gatsby/issues/270
